### PR TITLE
[XC]セクションの表示/追加/内容変更/セクションとタスクの紐付け

### DIFF
--- a/src/components/molecules/taskTable.vue
+++ b/src/components/molecules/taskTable.vue
@@ -1,0 +1,18 @@
+<template lang="pug">
+  el-table(:data="data",
+           :header-cell-style="{height: '32px', padding: '0'}",
+           :cell-style="{padding: '0'}",
+           border)
+    el-table-column(v-for="column in columns", :key="column.id", :label="column.label", :width="column.width")
+      template(slot-scope="scope")
+        el-input(v-model="scope.row[column.value]")
+</template>
+
+<script>
+export default {
+  props: {
+    data: Array,
+    columns: Array
+  }
+}
+</script>

--- a/src/components/molecules/taskTable.vue
+++ b/src/components/molecules/taskTable.vue
@@ -11,8 +11,16 @@
 <script>
 export default {
   props: {
-    data: Array,
-    columns: Array
+    data: {
+      type: Array,
+      default: function () {
+        return []
+      }
+    },
+    columns: {
+      type: Array,
+      required: true
+    }
   }
 }
 </script>

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -122,7 +122,7 @@ export default {
     padding: 0px;
   }
 
-  ::v-deep .el-input__inner {
+  .el-table ::v-deep .el-input__inner {
     height: $basespace-600;
     border-radius: 0px;
   }

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -21,7 +21,7 @@
             el-collapse-item(v-for="section in sectionList", :key="section.id", :title="section.label", :name="section.id", :disabled="judgeToEdit(section.id)")
               template(slot="title")
                 .section-title-area
-                  el-input(v-model="section.label", @click.native="editSectionTitle(section.id)", @blur="editingSectionId = ''", size="medium", :class="{ isEditing: judgeToEdit(section.id) }")
+                  el-input(v-model="section.label", @click.native="editSectionTitle(section.id)", @blur="editingSectionId = ''", size="medium", :class="{ is-editing: judgeToEdit(section.id) }")
               task-table.mt-100(:data="sectionTableData(section.id)", :columns="columnList")
 </template>
 
@@ -116,10 +116,10 @@ export default {
       this.selectedSectionId = ''
     },
     addSection () {
-      const sectionNumber = this.sectionList.length + 1
+      const newSectionId = this.sectionList.length + 1
       this.sectionList.push({
-        id: sectionNumber,
-        label: 'セクション' + sectionNumber
+        id: newSectionId,
+        label: 'セクション' + newSectionId
       })
     },
     sectionTableData (sectionId) {
@@ -146,7 +146,7 @@ export default {
     border-color: transparent;
   }
 
-  .isEditing ::v-deep .el-input__inner {
+  .is-editing ::v-deep .el-input__inner {
     border-color: #409EFF;
   }
 

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -11,8 +11,9 @@
           el-tag.ml-100(v-if="existEmptyTask", size="mini", effect="plain") 空のタスクが存在します
           hr
         el-main
+          task-table(:data="sectionTableData(0)", :columns="columnList")
           el-collapse(v-model="activeSections")
-            el-collapse-item(v-for="section in sectionList",:key="section.id", :title="section.label", :name="section.id")
+            el-collapse-item(v-for="section in sectionList", :key="section.id", :title="section.label", :name="section.id")
               task-table(:data="sectionTableData(section.id)", :columns="columnList")
 </template>
 
@@ -36,7 +37,7 @@ export default {
         { id: 1, label: '4/15~29のタスク' },
         { id: 2, label: '5/04~20のタスク' }
       ],
-      activeSections: ['1'],
+      activeSections: [1, 2],
       tableData: [{
         id: 1,
         section: 1,
@@ -71,7 +72,7 @@ export default {
         other: ''
       }, {
         id: 5,
-        section: 2,
+        section: '',
         name: 'タスクの削除',
         person: 'ジョニー',
         deadline: '5/05',
@@ -90,6 +91,7 @@ export default {
     addTask () {
       this.tableData.push({
         id: this.tableData.length + 1,
+        section: 0,
         name: '',
         person: '',
         deadline: '',

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -7,10 +7,10 @@
     el-main
       el-container
         el-header
-          el-button.mb-300(@click="addTask", :disabled="existEmptyTask", icon="el-icon-plus") タスクを追加
-          el-select.ml-100(v-model="selectedSectionId", :disabled="existEmptyTask", placeholder="セクションを選択", clearable)
+          el-button.mb-300(@click="addTask", :disabled="existEmptyTask", icon="el-icon-plus", size="mini") タスクを追加
+          el-select.ml-100(v-model="selectedSectionId", :disabled="existEmptyTask", placeholder="セクションを選択", size="mini", clearable)
             el-option(v-for="section in sectionList", :key="section.id", :label="section.label", :value="section.id")
-          el-tag.ml-100(v-if="existEmptyTask", size="mini", effect="plain") 空のタスクが存在します
+          el-tag.ml-100(v-if="existEmptyTask", size="small", type="danger", effect="plain") 空のタスクが存在します
           hr
         el-main
           task-table.mb-500(:data="notSectionedTableData", :columns="columnList")

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -18,7 +18,7 @@
         el-main
           task-table.mb-500(:data="notSectionedTableData", :columns="columnList")
           el-collapse(v-model="activeSections")
-            el-collapse-item(v-for="section in sectionList", :key="section.id", :disabled="section.id === editingSectionId", :title="section.label", :name="section.id")
+            el-collapse-item(v-for="section in sectionList", :key="section.id", :title="section.label", :name="section.id", :disabled="section.id === editingSectionId")
               template(slot="title")
                 .section-title-area(v-if="section.id === editingSectionId")
                   el-input(v-model="section.label", @blur="editingSectionId = ''", size="mini")

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -8,7 +8,7 @@
       el-container
         el-header
           el-button.mb-300(@click="addTask", :disabled="existEmptyTask", icon="el-icon-plus") タスクを追加
-          el-select(v-model="selectedSectionId", placeholder="セクションを選択", clearable)
+          el-select.ml-100(v-model="selectedSectionId", :disabled="existEmptyTask", placeholder="セクションを選択", clearable)
             el-option(v-for="section in sectionList", :key="section.id", :label="section.label", :value="section.id")
           el-tag.ml-100(v-if="existEmptyTask", size="mini", effect="plain") 空のタスクが存在します
           hr

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -21,8 +21,8 @@
             el-collapse-item(v-for="section in sectionList", :key="section.id", :title="section.label", :name="section.id", :disabled="judgeToEdit(section.id)")
               template(slot="title")
                 .section-title-area
-                  el-input(v-model="section.label", @click.native="editSectionTitle(section.id)", @blur="editingSectionId = ''", size="mini", :class="{ isEditing: judgeToEdit(section.id) }")
-              task-table(:data="sectionTableData(section.id)", :columns="columnList")
+                  el-input(v-model="section.label", @click.native="editSectionTitle(section.id)", @blur="editingSectionId = ''", size="medium", :class="{ isEditing: judgeToEdit(section.id) }")
+              task-table.mt-100(:data="sectionTableData(section.id)", :columns="columnList")
 </template>
 
 <script>
@@ -143,7 +143,7 @@ export default {
   }
 
   ::v-deep .el-collapse-item__header {
-    height: $basespace-600;
+    height: $basespace-500 * 2;
   }
 
   .section-title-area ::v-deep .el-input__inner {

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -18,12 +18,10 @@
         el-main
           task-table.mb-500(:data="notSectionedTableData", :columns="columnList")
           el-collapse(v-model="activeSections")
-            el-collapse-item(v-for="section in sectionList", :key="section.id", :title="section.label", :name="section.id", :disabled="section.id === editingSectionId")
+            el-collapse-item(v-for="section in sectionList", :key="section.id", :title="section.label", :name="section.id", :disabled="judgeToEdit(section.id)")
               template(slot="title")
-                .section-title-area(v-if="section.id === editingSectionId")
-                  el-input(v-model="section.label", @blur="editingSectionId = ''", size="mini")
-                .section-title-area(v-else)
-                  .fs-200(@click.stop="editSectionTitle(section.id)") {{ section.label }}
+                .section-title-area
+                  el-input(v-model="section.label", @click.native="editSectionTitle(section.id)", @blur="editingSectionId = ''", size="mini", :class="{ isEditing: judgeToEdit(section.id) }")
               task-table(:data="sectionTableData(section.id)", :columns="columnList")
 </template>
 
@@ -131,6 +129,9 @@ export default {
     },
     editSectionTitle (id) {
       this.editingSectionId = id
+    },
+    judgeToEdit (id) {
+      return id === this.editingSectionId
     }
   }
 }
@@ -139,6 +140,18 @@ export default {
 <style lang="scss" scoped>
   ::v-deep .cell {
     padding: 0px;
+  }
+
+  ::v-deep .el-collapse-item__header {
+    height: $basespace-600;
+  }
+
+  .section-title-area ::v-deep .el-input__inner {
+    border-color: transparent;
+  }
+
+  .isEditing ::v-deep .el-input__inner {
+    border-color: #409EFF;
   }
 
   .el-table ::v-deep .el-input__inner {

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -13,9 +13,9 @@
         el-main
           el-collapse(v-model="activeSections")
             el-collapse-item(title="4/15~29のタスク" name="1")
-              task-table(:data="tableData", :columns="columnList")
+              task-table(:data="sectionTableData(1)", :columns="columnList")
             el-collapse-item(title="5/04~20のタスク" name="2")
-              task-table(:data="tableData", :columns="columnList")
+              task-table(:data="sectionTableData(2)", :columns="columnList")
 </template>
 
 <script>
@@ -37,6 +37,7 @@ export default {
       activeSections: ['1'],
       tableData: [{
         id: 1,
+        section: 1,
         name: 'タスクの表示/追加/名前変更機能',
         person: 'ジョニー',
         deadline: '4/16',
@@ -44,6 +45,7 @@ export default {
         other: ''
       }, {
         id: 2,
+        section: 1,
         name: 'セクションの表示/追加/名前変更機能',
         person: 'ジョニー',
         deadline: '4/17',
@@ -51,6 +53,7 @@ export default {
         other: ''
       }, {
         id: 3,
+        section: 1,
         name: 'セクションとタスクの紐付け',
         person: 'ジョニー',
         deadline: '4/20',
@@ -58,10 +61,19 @@ export default {
         other: ''
       }, {
         id: 4,
-        name: 'タスク/セクションの並び替え機能',
+        section: 2,
+        name: 'タスクへのいいね機能',
         person: 'ジョニー',
-        deadline: '4/22',
-        tag: 'MVP',
+        deadline: '5/04',
+        tag: '開発目標',
+        other: ''
+      }, {
+        id: 5,
+        section: 2,
+        name: 'タスクの削除',
+        person: 'ジョニー',
+        deadline: '5/05',
+        tag: '開発目標',
         other: ''
       }]
     }
@@ -81,6 +93,11 @@ export default {
         deadline: '',
         tag: '',
         other: ''
+      })
+    },
+    sectionTableData (sectionId) {
+      return this.tableData.filter(row => {
+        return row.section === sectionId
       })
     }
   }

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -10,13 +10,17 @@
           el-button.mb-300(@click="addTask", size="mini", icon="el-icon-plus") タスクを追加
           hr
         el-main
-          el-table(:data="tableData",
-                   :header-cell-style="{height: '32px', padding: '0'}",
-                   :cell-style="{padding: '0'}",
-                   border)
-            el-table-column(v-for="column in columnList", :key="column.label", :label="column.label", :width="column.width")
-              template(slot-scope="scope")
-                el-input(v-model="scope.row[column.value]")
+          el-collapse(v-model="activeSections")
+            el-collapse-item(title="4/15~29のタスク" name="1")
+              el-table(:data="tableData",
+                       :header-cell-style="{height: '32px', padding: '0'}",
+                       :cell-style="{padding: '0'}",
+                       border)
+                el-table-column(v-for="column in columnList", :key="column.label", :label="column.label", :width="column.width")
+                  template(slot-scope="scope")
+                    el-input(v-model="scope.row[column.value]")
+            el-collapse-item(title="5/04~20のタスク" name="2")
+              div no contents
 </template>
 
 <script>
@@ -30,6 +34,7 @@ export default {
         { label: 'タグ', value: 'tag', width: 120 },
         { label: 'その他', value: 'other'},
       ],
+      activeSections: ['1'],
       tableData: [{
         name: 'タスクの表示/追加/名前変更機能',
         person: 'ジョニー',

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -6,12 +6,14 @@
       hr
     el-main
       el-container
-        el-header
-          el-button.mb-300(@click="addTask", :disabled="existEmptyTask", icon="el-icon-plus", size="mini") タスクを追加
-          el-select.ml-100(v-model="selectedSectionId", :disabled="existEmptyTask", placeholder="セクションを選択", size="mini", clearable)
-            el-option(v-for="section in sectionList", :key="section.id", :label="section.label", :value="section.id")
-          el-tag.ml-100(v-if="existEmptyTask", size="small", type="danger", effect="plain") 空のタスクが存在します
-          el-button.mb-300(@click="addSection", icon="el-icon-plus", size="mini") セクションを追加
+        el-header.mb-600
+          .mb-100
+            el-button(@click="addTask", :disabled="existEmptyTask", icon="el-icon-plus", size="mini") タスクを追加
+            el-select.ml-100(v-model="selectedSectionId", :disabled="existEmptyTask", placeholder="セクションを選択", size="mini", clearable)
+              el-option(v-for="section in sectionList", :key="section.id", :label="section.label", :value="section.id")
+            el-tag.ml-100(v-if="existEmptyTask", size="small", type="danger", effect="plain") 空のタスクが存在します
+          .mb-500
+            el-button(@click="addSection", icon="el-icon-plus", size="mini") セクションを追加
           hr
         el-main
           task-table.mb-500(:data="notSectionedTableData", :columns="columnList")

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -11,6 +11,7 @@
           el-select.ml-100(v-model="selectedSectionId", :disabled="existEmptyTask", placeholder="セクションを選択", size="mini", clearable)
             el-option(v-for="section in sectionList", :key="section.id", :label="section.label", :value="section.id")
           el-tag.ml-100(v-if="existEmptyTask", size="small", type="danger", effect="plain") 空のタスクが存在します
+          el-button.mb-300(@click="addSection", icon="el-icon-plus", size="mini") セクションを追加
           hr
         el-main
           task-table.mb-500(:data="notSectionedTableData", :columns="columnList")
@@ -113,6 +114,13 @@ export default {
         other: ''
       })
       this.selectedSectionId = ''
+    },
+    addSection () {
+      const sectionNumber = this.sectionList.length + 1
+      this.sectionList.push({
+        id: sectionNumber,
+        label: 'セクション' + sectionNumber
+      })
     },
     sectionTableData (sectionId) {
       return this.tableData.filter(row => {

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -7,11 +7,13 @@
     el-main
       el-container
         el-header
-          el-button.mb-300(@click="addTask", :disabled="existEmptyTask", size="mini", icon="el-icon-plus") タスクを追加
+          el-button.mb-300(@click="addTask", :disabled="existEmptyTask", icon="el-icon-plus") タスクを追加
+          el-select(v-model="selectedSectionId", placeholder="セクションを選択", clearable)
+            el-option(v-for="section in sectionList", :key="section.id", :label="section.label", :value="section.id")
           el-tag.ml-100(v-if="existEmptyTask", size="mini", effect="plain") 空のタスクが存在します
           hr
         el-main
-          task-table(:data="sectionTableData(0)", :columns="columnList")
+          task-table(:data="notSectionedTableData", :columns="columnList")
           el-collapse(v-model="activeSections")
             el-collapse-item(v-for="section in sectionList", :key="section.id", :title="section.label", :name="section.id")
               task-table(:data="sectionTableData(section.id)", :columns="columnList")
@@ -37,6 +39,7 @@ export default {
         { id: 1, label: '4/15~29のタスク' },
         { id: 2, label: '5/04~20のタスク' }
       ],
+      selectedSectionId: '',
       activeSections: [1, 2],
       tableData: [{
         id: 1,
@@ -72,7 +75,7 @@ export default {
         other: ''
       }, {
         id: 5,
-        section: '',
+        section: 2,
         name: 'タスクの削除',
         person: 'ジョニー',
         deadline: '5/05',
@@ -85,19 +88,25 @@ export default {
     existEmptyTask () {
       const lastTask = this.tableData[this.tableData.length - 1]
       return lastTask.name === ''
+    },
+    notSectionedTableData () {
+      return this.tableData.filter(row => {
+        return row.section === ''
+      })
     }
   },
   methods: {
     addTask () {
       this.tableData.push({
         id: this.tableData.length + 1,
-        section: 0,
+        section: this.selectedSectionId,
         name: '',
         person: '',
         deadline: '',
         tag: '',
         other: ''
       })
+      this.selectedSectionId = ''
     },
     sectionTableData (sectionId) {
       return this.tableData.filter(row => {

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -18,7 +18,7 @@
         el-main
           task-table.mb-500(:data="notSectionedTableData", :columns="columnList")
           el-collapse(v-model="activeSections")
-            el-collapse-item(v-for="section in sectionList", :key="section.id", :title="section.label", :name="section.id")
+            el-collapse-item(v-for="section in sectionList", :key="section.id", :disabled="section.id === editingSectionId", :title="section.label", :name="section.id")
               template(slot="title")
                 .section-title-area(v-if="section.id === editingSectionId")
                   el-input(v-model="section.label", @blur="editingSectionId = ''", size="mini")

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -16,6 +16,11 @@
           task-table.mb-500(:data="notSectionedTableData", :columns="columnList")
           el-collapse(v-model="activeSections")
             el-collapse-item(v-for="section in sectionList", :key="section.id", :title="section.label", :name="section.id")
+              template(slot="title")
+                .section-title-area(v-if="section.id === editingSectionId")
+                  el-input(v-model="section.label", @blur="editingSectionId = ''", size="mini")
+                .section-title-area(v-else)
+                  .fs-200(@click.stop="editSectionTitle(section.id)") {{ section.label }}
               task-table(:data="sectionTableData(section.id)", :columns="columnList")
 </template>
 
@@ -41,6 +46,7 @@ export default {
       ],
       selectedSectionId: '',
       activeSections: [1, 2],
+      editingSectionId: '',
       tableData: [{
         id: 1,
         section: 1,
@@ -112,6 +118,9 @@ export default {
       return this.tableData.filter(row => {
         return row.section === sectionId
       })
+    },
+    editSectionTitle (id) {
+      this.editingSectionId = id
     }
   }
 }

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -138,10 +138,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  ::v-deep .cell {
-    padding: 0px;
-  }
-
   ::v-deep .el-collapse-item__header {
     height: $basespace-500 * 2;
   }
@@ -157,6 +153,10 @@ export default {
   .el-table ::v-deep .el-input__inner {
     height: $basespace-600;
     border-radius: 0px;
+  }
+
+  ::v-deep .cell {
+    padding: 0px;
   }
 
   ::v-deep td:first-child  {

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -13,7 +13,7 @@
           el-tag.ml-100(v-if="existEmptyTask", size="mini", effect="plain") 空のタスクが存在します
           hr
         el-main
-          task-table(:data="notSectionedTableData", :columns="columnList")
+          task-table.mb-500(:data="notSectionedTableData", :columns="columnList")
           el-collapse(v-model="activeSections")
             el-collapse-item(v-for="section in sectionList", :key="section.id", :title="section.label", :name="section.id")
               task-table(:data="sectionTableData(section.id)", :columns="columnList")

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -12,10 +12,8 @@
           hr
         el-main
           el-collapse(v-model="activeSections")
-            el-collapse-item(title="4/15~29のタスク" name="1")
-              task-table(:data="sectionTableData(1)", :columns="columnList")
-            el-collapse-item(title="5/04~20のタスク" name="2")
-              task-table(:data="sectionTableData(2)", :columns="columnList")
+            el-collapse-item(v-for="section in sectionList",:key="section.id", :title="section.label", :name="section.id")
+              task-table(:data="sectionTableData(section.id)", :columns="columnList")
 </template>
 
 <script>
@@ -33,6 +31,10 @@ export default {
         { id: 3, label: '期日', value: 'deadline', width: 120 },
         { id: 4, label: 'タグ', value: 'tag', width: 120 },
         { id: 5, label: 'その他', value: 'other'},
+      ],
+      sectionList: [
+        { id: 1, label: '4/15~29のタスク' },
+        { id: 2, label: '5/04~20のタスク' }
       ],
       activeSections: ['1'],
       tableData: [{

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -13,19 +13,18 @@
         el-main
           el-collapse(v-model="activeSections")
             el-collapse-item(title="4/15~29のタスク" name="1")
-              el-table(:data="tableData",
-                       :header-cell-style="{height: '32px', padding: '0'}",
-                       :cell-style="{padding: '0'}",
-                       border)
-                el-table-column(v-for="column in columnList", :key="column.id", :label="column.label", :width="column.width")
-                  template(slot-scope="scope")
-                    el-input(v-model="scope.row[column.value]")
+              task-table(:data="tableData", :columns="columnList")
             el-collapse-item(title="5/04~20のタスク" name="2")
-              div no contents
+              task-table(:data="tableData", :columns="columnList")
 </template>
 
 <script>
+import taskTable from '@/components/molecules/taskTable'
+
 export default {
+  components: {
+    taskTable
+  },
   data () {
     return {
       columnList: [

--- a/src/main.js
+++ b/src/main.js
@@ -1,10 +1,11 @@
 import Vue from 'vue'
 import ElementUI from 'element-ui'
+import locale from 'element-ui/lib/locale/lang/ja'
 import 'element-ui/lib/theme-chalk/index.css'
 import App from './App.vue'
 
 Vue.config.productionTip = false
-Vue.use(ElementUI)
+Vue.use(ElementUI, { locale })
 
 new Vue({
   render: h => h(App),


### PR DESCRIPTION
## 概要
- セクションの表示/追加/内容変更
- セクションとタスクの紐付け

## 技術的変更点概要
- taskTableを切り出した
- el-collapseでセクションを再現した
- セクションをsectionListで管理し、tableDataの各オブジェクトにsectionプロパティを持たせて紐付けられるようにした

## 使い方
- セクションを選択せずに「タスクを追加」ボタンを押して、一番上のエリアに空のタスクを追加
- セクションを選択してから「タスクを追加」ボタンを押して、選択したセクション内に空のタスクを追加
- 「セクションを追加」ボタンを押して、一番下のエリアに空のセクションを追加
- セクション名をクリックしてセクション名を変更
![f287c25742285b0f13712a6a4ce67fab](https://user-images.githubusercontent.com/38747501/79831990-74495800-83e3-11ea-91ef-9b73d58054b0.gif)

## UIに対する変更
- 変更後のスクリーンショット
![スクリーンショット 2020-04-21 15 08 31](https://user-images.githubusercontent.com/38747501/79831342-31d34b80-83e2-11ea-8f54-8ef533a76404.png)

- 変更前のスクリーンショット
![スクリーンショット 2020-04-21 15 08 41](https://user-images.githubusercontent.com/38747501/79831349-3697ff80-83e2-11ea-82ca-378cc73e6ed4.png)

## テスト結果とテスト項目
- [x] セクション名クリック時にセクションが開閉しない

## 今回保留した項目とTODOリスト
- 特になし

## その他
- CSSがより複雑になってきて不安です…

## 関連URL
- 研修の目的
https://smartcamp.kibe.la/notes/3813
- スケジュール
https://smartcamp.kibe.la/notes/3816