### PR TITLE
[XC]タスクへのいいね機能

### DIFF
--- a/src/components/atoms/JIconButton.vue
+++ b/src/components/atoms/JIconButton.vue
@@ -13,7 +13,11 @@ export default {
       type: String,
       required: true
     },
-    type: {
+    color: {
+      type: String,
+      default: 'default'
+    },
+    hoverColor: {
       type: String,
       default: 'default'
     }
@@ -21,8 +25,11 @@ export default {
   classes (props) {
     return {
       'j-icon-button': true,
-      'j-icon-button-default': props.type === 'default',
-      'j-icon-button-success': props.type === 'success'
+      'j-icon-button-default': props.color === 'default',
+      'j-icon-button-primary': props.color === 'primary',
+      'j-icon-button-hover-default': props.hoverColor === 'default',
+      'j-icon-button-hover-primary': props.hoverColor === 'primary',
+      'j-icon-button-hover-success': props.hoverColor === 'success'
     }
   }
 }
@@ -30,15 +37,25 @@ export default {
 
 <style lang="scss" scoped>
   .j-icon-button {
-    color: $bdcolor-base;
     cursor: pointer;
   }
-  .j-icon-button-default{
+  .j-icon-button-default {
+    color: $bdcolor-base;
+  }
+  .j-icon-button-primary {
+    color: $basecolor-secondary;
+  }
+  .j-icon-button-hover-default {
     &:hover {
       color: $bdcolor-dark;
     }
   }
-  .j-icon-button-success{
+  .j-icon-button-hover-primary {
+    &:hover {
+      color: $basecolor-secondary;
+    }
+  }
+  .j-icon-button-hover-success {
     &:hover {
       color: $basecolor-success;
     }

--- a/src/components/molecules/TaskTable.vue
+++ b/src/components/molecules/TaskTable.vue
@@ -8,7 +8,7 @@
         .task-list-item(v-for="row in data", :key="row.id")
           j-move-icon
           span.complete-button-area
-            j-icon-button(genre="far", value="check-circle", type="success", @click="completeTask(row.id)")
+            j-icon-button(genre="far", value="check-circle", hover-color="success", @click="completeTask(row.id)")
           template(v-for="(column, index) in columns")
             el-input(v-model="row.data[column.value]", :style="{ width: column.width + 'px' }")
             .open-modal-button-area(v-if="index === 0", @click="openTaskDetailModal(row.id)")

--- a/src/components/molecules/TaskTable.vue
+++ b/src/components/molecules/TaskTable.vue
@@ -3,8 +3,7 @@
     template(v-for="(column, index) in columns")
       el-input.header(v-model="column.label", :style="{ width: column.width + 'px' }", readonly)
       span(v-if="index === 0")
-        .like-button-area
-        .open-modal-button-area
+        .task-action-space
     draggable(group="tasks")
       transition-group(name="task-list", tag="div")
         .task-list-item(v-for="row in data", :key="row.id")
@@ -14,10 +13,9 @@
           template(v-for="(column, index) in columns")
             el-input(v-model="row.data[column.value]", :style="{ width: column.width + 'px' }")
             span(v-if="index === 0")
-              .like-button-area
-                j-icon-button(v-if="row.liked", genre="far", value="thumbs-up", color="primary", hover-color="primary", @click="switchLiked(row.id)")
-              .open-modal-button-area(@click="openTaskDetailModal(row.id)")
-                span 詳細 >
+              .task-action-space
+                j-icon-button.mx-100(v-if="row.liked", genre="far", value="thumbs-up", color="primary", hover-color="primary", @click="switchLiked(row.id)")
+                .open-modal-button.fs-100.mx-200(@click="openTaskDetailModal(row.id)") 詳細 >
 </template>
 
 <script>
@@ -81,16 +79,13 @@ export default {
     margin: 0 $basespace-100;
     vertical-align: middle;
   }
-  .like-button-area {
+  .task-action-space {
     display: inline-block;
-    text-align: center;
-    width: $basespace-600;
+    text-align: right;
+    width: $basespace-600 * 3;
   }
-  .open-modal-button-area {
+  .open-modal-button {
     display: inline-block;
-    text-align: center;
-    width: $basespace-600 * 2;
-    font-size: $basespace-200;
     cursor: pointer;
     opacity: 0;
     &:hover {

--- a/src/components/molecules/TaskTable.vue
+++ b/src/components/molecules/TaskTable.vue
@@ -2,7 +2,9 @@
   div.pl-600
     template(v-for="(column, index) in columns")
       el-input.header(v-model="column.label", :style="{ width: column.width + 'px' }", readonly)
-      .open-modal-button-area(v-if="index === 0")
+      span(v-if="index === 0")
+        .like-button-area
+        .open-modal-button-area
     draggable(group="tasks")
       transition-group(name="task-list", tag="div")
         .task-list-item(v-for="row in data", :key="row.id")
@@ -11,8 +13,11 @@
             j-icon-button(genre="far", value="check-circle", hover-color="success", @click="completeTask(row.id)")
           template(v-for="(column, index) in columns")
             el-input(v-model="row.data[column.value]", :style="{ width: column.width + 'px' }")
-            .open-modal-button-area(v-if="index === 0", @click="openTaskDetailModal(row.id)")
-              span 詳細 >
+            span(v-if="index === 0")
+              .like-button-area
+                j-icon-button(v-if="row.liked", genre="far", value="thumbs-up", color="primary", hover-color="primary", @click="switchLiked(row.id)")
+              .open-modal-button-area(@click="openTaskDetailModal(row.id)")
+                span 詳細 >
 </template>
 
 <script>
@@ -41,6 +46,9 @@ export default {
   methods: {
     completeTask (taskId) {
       this.$emit('completeTask', taskId, this.sectionValue)
+    },
+    switchLiked (taskId) {
+      this.$emit('switchLiked', taskId, this.sectionValue)
     },
     openTaskDetailModal (taskId) {
       this.$emit('openTaskDetailModal', taskId, this.sectionValue)
@@ -72,6 +80,11 @@ export default {
   .complete-button-area {
     margin: 0 $basespace-100;
     vertical-align: middle;
+  }
+  .like-button-area {
+    display: inline-block;
+    text-align: center;
+    width: $basespace-600;
   }
   .open-modal-button-area {
     display: inline-block;

--- a/src/components/organisms/ContentHeader.vue
+++ b/src/components/organisms/ContentHeader.vue
@@ -28,7 +28,7 @@ export default {
         return acc.concat(this.tableData[key])
       }, [])
       const emptyTasks = allTasks.filter((task) => {
-        return task.name === ''
+        return task.data.name === ''
       })
       return emptyTasks.length > 0
     }

--- a/src/components/organisms/ContentHeader.vue
+++ b/src/components/organisms/ContentHeader.vue
@@ -37,11 +37,16 @@ export default {
     addTask () {
       const emptyTask = {
         id: this.taskTotalNumber+ 1,
-        name: '',
-        person: '',
-        deadline: '',
-        tag: '',
-        other: ''
+        completedAt: '',
+        deletedAt: '',
+        liked: false,
+        data: {
+          name: '',
+          person: '',
+          deadline: '',
+          tag: '',
+          other: ''
+        }
       }
       if (this.selectedSectionValue === '') {
         this.$emit('addTask', 'notSectioned', emptyTask)

--- a/src/components/organisms/TaskDetailModal.vue
+++ b/src/components/organisms/TaskDetailModal.vue
@@ -3,6 +3,7 @@
     el-header
       .header-button-area.my-300
         el-button(@click="completeTask", icon="el-icon-check", size="mini") 完了にする
+        j-icon-button.ml-a.mr-400(genre="far", value="thumbs-up", @click="closeTaskDetailModal")
         j-icon-button.mr-200(genre="fas", value="chevron-right", @click="closeTaskDetailModal")
       hr
     el-main
@@ -35,7 +36,6 @@ export default {
 <style lang="scss" scoped>
   .header-button-area {
     display: flex;
-    justify-content: space-between;
     align-items: center;
   }
 </style>

--- a/src/components/organisms/TaskDetailModal.vue
+++ b/src/components/organisms/TaskDetailModal.vue
@@ -7,12 +7,12 @@
         j-icon-button.mr-200(genre="fas", value="chevron-right", @click="closeTaskDetailModal")
       hr
     el-main
-      .fs-600.fw-bold.mb-400 {{ task[columnList[0].value] }}
+      .fs-600.fw-bold.mb-400 {{ task.data[columnList[0].value] }}
       el-row.mb-200(v-for="column in columnList.slice(1)", :key="column.id")
         el-col.pt-100(:span="6")
           span {{ column.label }}
         el-col(:span="18")
-          el-input(v-model="task[column.value]")
+          el-input(v-model="task.data[column.value]")
 </template>
 
 <script>

--- a/src/components/organisms/TaskDetailModal.vue
+++ b/src/components/organisms/TaskDetailModal.vue
@@ -3,7 +3,7 @@
     el-header
       .header-button-area.my-300
         el-button(@click="completeTask", icon="el-icon-check", size="mini") 完了にする
-        j-icon-button.ml-a.mr-400(genre="far", value="thumbs-up", @click="closeTaskDetailModal")
+        j-icon-button.ml-a.mr-400(genre="far", value="thumbs-up", @click="giveLikeToTask")
         j-icon-button.mr-200(genre="fas", value="chevron-right", @click="closeTaskDetailModal")
       hr
     el-main
@@ -25,6 +25,9 @@ export default {
   methods: {
     completeTask () {
       this.$emit('completeTask', this.task.id, this.sectionValue)
+    },
+    giveLikeToTask () {
+      this.$emit('giveLikeToTask', this.task.id, this.sectionValue)
     },
     closeTaskDetailModal () {
       this.$emit('closeTaskDetailModal')

--- a/src/components/organisms/TaskDetailModal.vue
+++ b/src/components/organisms/TaskDetailModal.vue
@@ -3,7 +3,9 @@
     el-header
       .header-button-area.my-300
         el-button(@click="completeTask", icon="el-icon-check", size="mini") 完了にする
-        j-icon-button.ml-a.mr-400(genre="far", value="thumbs-up", @click="giveLikeToTask")
+        .ml-a
+          j-icon-button.mr-400(v-if="!task.liked", genre="far", value="thumbs-up", @click="switchLiked")
+          j-icon-button.mr-400(v-if="task.liked", genre="far", value="thumbs-up", color="primary", hover-color="", @click="switchLiked")
         j-icon-button.mr-200(genre="fas", value="chevron-right", @click="closeTaskDetailModal")
       hr
     el-main
@@ -26,8 +28,8 @@ export default {
     completeTask () {
       this.$emit('completeTask', this.task.id, this.sectionValue)
     },
-    giveLikeToTask () {
-      this.$emit('giveLikeToTask', this.task.id, this.sectionValue)
+    switchLiked () {
+      this.$emit('switchLiked', this.task.id, this.sectionValue)
     },
     closeTaskDetailModal () {
       this.$emit('closeTaskDetailModal')

--- a/src/components/organisms/TaskDetailModal.vue
+++ b/src/components/organisms/TaskDetailModal.vue
@@ -5,7 +5,7 @@
         el-button(@click="completeTask", icon="el-icon-check", size="mini") 完了にする
         .ml-a
           j-icon-button.mr-400(v-if="!task.liked", genre="far", value="thumbs-up", @click="switchLiked")
-          j-icon-button.mr-400(v-else, genre="far", value="thumbs-up", color="primary", hover-color="", @click="switchLiked")
+          j-icon-button.mr-400(v-else, genre="far", value="thumbs-up", color="primary", hover-color="primary", @click="switchLiked")
         j-icon-button.mr-200(genre="fas", value="chevron-right", @click="closeTaskDetailModal")
       hr
     el-main

--- a/src/components/organisms/TaskDetailModal.vue
+++ b/src/components/organisms/TaskDetailModal.vue
@@ -5,7 +5,7 @@
         el-button(@click="completeTask", icon="el-icon-check", size="mini") 完了にする
         .ml-a
           j-icon-button.mr-400(v-if="!task.liked", genre="far", value="thumbs-up", @click="switchLiked")
-          j-icon-button.mr-400(v-if="task.liked", genre="far", value="thumbs-up", color="primary", hover-color="", @click="switchLiked")
+          j-icon-button.mr-400(v-else, genre="far", value="thumbs-up", color="primary", hover-color="", @click="switchLiked")
         j-icon-button.mr-200(genre="fas", value="chevron-right", @click="closeTaskDetailModal")
       hr
     el-main

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -28,7 +28,7 @@
                                   @openTaskDetailModal="openTaskDetailModal")
       transition(name="task-detail-modal")
         .task-detail-modal-area(v-if="showTaskDetailModal")
-          task-detail-modal(:task="taskDetailModalContent", :sectionValue="taskDetailModalSectionValue", :columnList="columnList", @completeTask="completeTask", @closeTaskDetailModal="closeTaskDetailModal")
+          task-detail-modal(:task="taskDetailModalContent", :sectionValue="taskDetailModalSectionValue", :columnList="columnList", @completeTask="completeTask", @giveLikeToTask="giveLikeToTask", @closeTaskDetailModal="closeTaskDetailModal")
 </template>
 
 <script>
@@ -66,6 +66,7 @@ export default {
         notSectioned: [{
             id: 1,
             completedAt: '',
+            liked: false,
             data: {
               name: 'JavaScriptの勉強',
               person: 'ジョニー',
@@ -77,6 +78,7 @@ export default {
         section1: [{
           id: 2,
           completedAt: '',
+          liked: false,
           data: {
             name: 'タスクの表示/追加/名前変更機能',
             person: 'ジョニー',
@@ -87,6 +89,7 @@ export default {
         }, {
           id: 3,
           completedAt: '',
+          liked: false,
           data: {
             name: 'セクションの表示/追加/名前変更機能',
             person: 'ジョニー',
@@ -97,6 +100,7 @@ export default {
         }, {
           id: 4,
           completedAt: '',
+          liked: false,
           data: {
             name: 'セクションとタスクの紐付け',
             person: 'ジョニー',
@@ -108,6 +112,7 @@ export default {
         section2: [{
           id: 5,
           completedAt: '',
+          liked: false,
           data: {
             name: 'タスクへのいいね機能',
             person: 'ジョニー',
@@ -118,6 +123,7 @@ export default {
         }, {
           id: 6,
           completedAt: '',
+          liked: false,
           data: {
             name: 'タスクの削除',
             person: 'ジョニー',
@@ -168,6 +174,12 @@ export default {
       if (taskId === this.taskDetailModalContent.id) {
         this.showTaskDetailModal = false
       }
+    },
+    giveLikeToTask (taskId, sectionValue) {
+      const targetTask = this.tableData[sectionValue].find((task) => {
+        return task.id === taskId
+      })
+      targetTask.liked = true
     },
     openTaskDetailModal (taskId, sectionValue) {
       this.taskDetailModalSectionValue = sectionValue

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -28,7 +28,7 @@
                                   @openTaskDetailModal="openTaskDetailModal")
       transition(name="task-detail-modal")
         .task-detail-modal-area(v-if="showTaskDetailModal")
-          task-detail-modal(:task="taskDetailModalContent", :sectionValue="taskDetailModalSectionValue", :columnList="columnList", @completeTask="completeTask", @giveLikeToTask="giveLikeToTask", @closeTaskDetailModal="closeTaskDetailModal")
+          task-detail-modal(:task="taskDetailModalContent", :sectionValue="taskDetailModalSectionValue", :columnList="columnList", @completeTask="completeTask", @switchLiked="switchLiked", @closeTaskDetailModal="closeTaskDetailModal")
 </template>
 
 <script>
@@ -175,11 +175,15 @@ export default {
         this.showTaskDetailModal = false
       }
     },
-    giveLikeToTask (taskId, sectionValue) {
+    switchLiked (taskId, sectionValue) {
       const targetTask = this.tableData[sectionValue].find((task) => {
         return task.id === taskId
       })
-      targetTask.liked = true
+      if (targetTask.liked) {
+        targetTask.liked = false
+      } else {
+        targetTask.liked = true
+      }
     },
     openTaskDetailModal (taskId, sectionValue) {
       this.taskDetailModalSectionValue = sectionValue

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -150,6 +150,7 @@ export default {
       const newSectionValue = 'section' + newSectionId
       this.sectionList.push({
         id: newSectionId,
+        deletedAt: '',
         label: 'セクション' + newSectionId,
         value: newSectionValue
       })

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -14,6 +14,7 @@
               task-table.mb-500(:data="filterCompletedTasks(tableData.notSectioned)",
                                 :columns="columnList",
                                 @completeTask="completeTask",
+                                @switchLiked="switchLiked",
                                 @openTaskDetailModal="openTaskDetailModal")
               el-collapse-item(v-for="section in sectionList", :key="section.id", :title="section.label", :name="section.id", :disabled="judgeToEdit(section.id)")
                 template(slot="title")
@@ -25,6 +26,7 @@
                                   :columns="columnList",
                                   :sectionValue="section.value",
                                   @completeTask="completeTask",
+                                  @switchLiked="switchLiked",
                                   @openTaskDetailModal="openTaskDetailModal")
       transition(name="task-detail-modal")
         .task-detail-modal-area(v-if="showTaskDetailModal")


### PR DESCRIPTION
## 概要
- タスクへのいいねを出来るように

## 技術的変更点概要
- JIconButtonのスタイルをより動的に変更できるようにした
- taskTable内にいいねボタンを表示するスペースを作った
- タスクのデータ構造を変えた

## 使い方
- タスク詳細モーダルの右上のいいねボタンでいいねの設定/解除ができる
- いいねされたタスクは、テーブル内のボタンからもいいね解除ができる
![bc8ff5d06228d8def785cc482a929d82](https://user-images.githubusercontent.com/38747501/81379452-1c7d5180-9144-11ea-9e8d-ae84bd9c71dd.gif)

## UIに対する変更
- 変更後のスクリーンショット
![スクリーンショット 2020-05-08 15 55 38](https://user-images.githubusercontent.com/38747501/81379622-67976480-9144-11ea-8ced-5263f7e16f78.png)

- 変更前のスクリーンショット
![image](https://user-images.githubusercontent.com/38747501/80192122-b1b31d00-8651-11ea-8c40-3be10082d1d7.png)

## テスト結果とテスト項目
- [x] いいねボタンの上にマウスを持っていくと色が変わる
- [x] いいねボタンを押すと、いいねボタンの色が変わりテーブル内にいいねボタンが表示される
- [x] いいねが設定された状態でタスク詳細モーダル内のいいねボタンを押すと、いいねが解除される
- [x] いいねが設定された状態でテーブル内のいいねボタンを押すと、いいねが解除される

## 今回保留した項目とTODOリスト
- 特になし

## その他
- すぐ出来ました😊

## 関連URL
- 研修の目的
https://smartcamp.kibe.la/notes/3813
- スケジュール
https://smartcamp.kibe.la/notes/3816