### PR TITLE
[XC]タスクの削除、セクションの削除

### DIFF
--- a/src/components/organisms/ContentHeader.vue
+++ b/src/components/organisms/ContentHeader.vue
@@ -37,11 +37,16 @@ export default {
     addTask () {
       const emptyTask = {
         id: this.taskTotalNumber+ 1,
-        name: '',
-        person: '',
-        deadline: '',
-        tag: '',
-        other: ''
+        completedAt: '',
+        deletedAt: '',
+        liked: false,
+        data: {
+          name: '',
+          person: '',
+          deadline: '',
+          tag: '',
+          other: ''
+        }
       }
       if (this.selectedSectionValue === '') {
         this.$emit('addTask', 'notSectioned', emptyTask)

--- a/src/components/organisms/TaskDetailModal.vue
+++ b/src/components/organisms/TaskDetailModal.vue
@@ -2,10 +2,11 @@
   el-container
     el-header
       .header-button-area.my-300
-        el-button(@click="completeTask", icon="el-icon-check", size="mini") 完了にする
-        .ml-a
+        el-button.mr-a(@click="completeTask", icon="el-icon-check", size="mini") 完了にする
+        div
           j-icon-button.mr-400(v-if="!task.liked", genre="far", value="thumbs-up", @click="switchLiked")
           j-icon-button.mr-400(v-else, genre="far", value="thumbs-up", color="primary", hover-color="", @click="switchLiked")
+        j-icon-button.mr-400(genre="far", value="trash-alt", @click="deleteTask")
         j-icon-button.mr-200(genre="fas", value="chevron-right", @click="closeTaskDetailModal")
       hr
     el-main
@@ -27,6 +28,9 @@ export default {
   methods: {
     completeTask () {
       this.$emit('completeTask', this.task.id, this.sectionValue)
+    },
+    deleteTask () {
+      this.$emit('deleteTask', this.task.id, this.sectionValue)
     },
     switchLiked () {
       this.$emit('switchLiked', this.task.id, this.sectionValue)

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -6,7 +6,7 @@
     el-main
       el-container
         el-header.mb-600
-          content-header(:sectionList="sectionList", :tableData="tableData", :taskTotalNumber="taskTotalNumber", @addTask="addTask", @addSection="addSection")
+          content-header(:sectionList="filterDeletedSections(sectionList)", :tableData="tableData", :taskTotalNumber="taskTotalNumber", @addTask="addTask", @addSection="addSection")
           hr
         el-main
           el-collapse(v-model="activeSections")
@@ -16,12 +16,12 @@
                                 @completeTask="completeTask",
                                 @switchLiked="switchLiked",
                                 @openTaskDetailModal="openTaskDetailModal")
-              el-collapse-item(v-for="section in sectionList", :key="section.id", :title="section.label", :name="section.id", :disabled="judgeToEdit(section.id)")
+              el-collapse-item(v-for="section in filterDeletedSections(sectionList)", :key="section.id", :title="section.label", :name="section.id", :disabled="judgeToEdit(section.id)")
                 template(slot="title")
                   j-move-icon
                   .section-title-area
                     el-input(v-model="section.label", @click.native="editSectionTitle(section.id)", @blur="editingSectionId = ''", size="medium", :class="{ 'is-editing': judgeToEdit(section.id) }")
-                  j-icon-button(genre="far", value="trash-alt", @click="deleteSection")
+                  j-icon-button(genre="far", value="trash-alt", @click="deleteSection(section)")
                 task-table.mt-100(:data="filterHiddenTasks(tableData[section.value])",
                                   :columns="columnList",
                                   :sectionValue="section.value",
@@ -56,8 +56,8 @@ export default {
         { id: 5, label: 'その他', value: 'other', width: 100 }
       ],
       sectionList: [
-        { id: 1, label: '4/15~29のタスク', value: 'section1' },
-        { id: 2, label: '5/04~20のタスク', value: 'section2' }
+        { id: 1, deletedAt: '', label: '4/15~29のタスク', value: 'section1' },
+        { id: 2, deletedAt: '', label: '5/04~20のタスク', value: 'section2' }
       ],
       activeSections: [1, 2],
       editingSectionId: '',
@@ -166,6 +166,11 @@ export default {
     judgeToEdit (id) {
       return id === this.editingSectionId
     },
+    filterDeletedSections (sections) {
+      return sections.filter((section) => {
+        return section.deletedAt === ''
+      })
+    },
     filterHiddenTasks (tasks) {
       return tasks.filter((task) => {
         return task.completedAt === '' & task.deletedAt === ''
@@ -181,6 +186,9 @@ export default {
         this.showTaskDetailModal = false
       }
     },
+    deleteSection (section) {
+      section.deletedAt = Date()
+    },
     deleteTask (taskId, sectionValue) {
       const targetTask = this.tableData[sectionValue].find((task) => {
         return task.id === taskId
@@ -188,9 +196,6 @@ export default {
       targetTask.deletedAt = Date()
       this.taskTotalNumber -= 1
       this.showTaskDetailModal = false
-    },
-    deleteSection () {
-
     },
     switchLiked (taskId, sectionValue) {
       const targetTask = this.tableData[sectionValue].find((task) => {

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -174,7 +174,7 @@ export default {
     },
     filterTasks (tasks) {
       return tasks.filter((task) => {
-        return task.completedAt === '' & task.deletedAt === ''
+        return task.completedAt === '' && task.deletedAt === ''
       })
     },
     completeTask (taskId, sectionValue) {

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -201,6 +201,7 @@ export default {
             message: section.label + 'は削除されました'
           })
           section.deletedAt = Date()
+          this.showTaskDetailModal = false
         }).catch(() => {
           this.$message({
             type: 'info',

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -21,7 +21,7 @@
                   j-move-icon
                   .section-title-area
                     el-input(v-model="section.label", @click.native="editSectionTitle(section.id)", @blur="editingSectionId = ''", size="medium", :class="{ 'is-editing': judgeToEdit(section.id) }")
-                  j-icon-button(genre="far", value="trash-alt", @click="deleteSection(section)")
+                  j-icon-button(genre="far", value="trash-alt", @click.stop="deleteSection(section)")
                 task-table.mt-100(:data="filterHiddenTasks(tableData[section.value])",
                                   :columns="columnList",
                                   :sectionValue="section.value",
@@ -154,6 +154,7 @@ export default {
       const newSectionValue = 'section' + newSectionId
       this.sectionList.push({
         id: newSectionId,
+        deletedAt: '',
         label: 'セクション' + newSectionId,
         value: newSectionValue
       })
@@ -187,7 +188,25 @@ export default {
       }
     },
     deleteSection (section) {
-      section.deletedAt = Date()
+      this.$confirm(
+        '紐付いたタスクを含む「' + section.label + '」のすべてが削除されます。',
+        'セクションを削除してもよろしいですか？',
+        {
+          confirmButtonText: 'セクションを削除',
+          cancelButtonText: 'キャンセル',
+          type: 'warning'
+        }).then(() => {
+          this.$message({
+            type: 'success',
+            message: section.label + 'は削除されました'
+          })
+          section.deletedAt = Date()
+        }).catch(() => {
+          this.$message({
+            type: 'info',
+            message: '削除はキャンセルされました'
+          })
+        })
     },
     deleteTask (taskId, sectionValue) {
       const targetTask = this.tableData[sectionValue].find((task) => {

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -19,7 +19,7 @@
               el-collapse-item(v-for="section in sectionList", :key="section.id", :title="section.label", :name="section.id", :disabled="judgeToEdit(section.id)")
                 template(slot="title")
                   .pt-100
-                    JMoveIcon
+                    j-move-icon
                   .section-title-area
                     el-input(v-model="section.label", @click.native="editSectionTitle(section.id)", @blur="editingSectionId = ''", size="medium", :class="{ 'is-editing': judgeToEdit(section.id) }")
                 task-table.mt-100(:data="filterHiddenTasks(tableData[section.value])",

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -6,23 +6,23 @@
     el-main
       el-container
         el-header.mb-600
-          content-header(:sectionList="filterDeletedSections(sectionList)", :tableData="tableData", :taskTotalNumber="taskTotalNumber", @addTask="addTask", @addSection="addSection")
+          content-header(:sectionList="filterSections(sectionList)", :tableData="tableData", :taskTotalNumber="taskTotalNumber", @addTask="addTask", @addSection="addSection")
           hr
         el-main
           el-collapse(v-model="activeSections")
             draggable
-              task-table.mb-500(:data="filterHiddenTasks(tableData.notSectioned)",
+              task-table.mb-500(:data="filterTasks(tableData.notSectioned)",
                                 :columns="columnList",
                                 @completeTask="completeTask",
                                 @switchLiked="switchLiked",
                                 @openTaskDetailModal="openTaskDetailModal")
-              el-collapse-item(v-for="section in filterDeletedSections(sectionList)", :key="section.id", :title="section.label", :name="section.id", :disabled="judgeToEdit(section.id)")
+              el-collapse-item(v-for="section in filterSections(sectionList)", :key="section.id", :title="section.label", :name="section.id", :disabled="judgeToEdit(section.id)")
                 template(slot="title")
                   j-move-icon
                   .section-title-area
                     el-input(v-model="section.label", @click.native="editSectionTitle(section.id)", @blur="editingSectionId = ''", size="medium", :class="{ 'is-editing': judgeToEdit(section.id) }")
                   j-icon-button(genre="far", value="trash-alt", @click.stop="deleteSection(section)")
-                task-table.mt-100(:data="filterHiddenTasks(tableData[section.value])",
+                task-table.mt-100(:data="filterTasks(tableData[section.value])",
                                   :columns="columnList",
                                   :sectionValue="section.value",
                                   @completeTask="completeTask",
@@ -167,12 +167,12 @@ export default {
     judgeToEdit (id) {
       return id === this.editingSectionId
     },
-    filterDeletedSections (sections) {
+    filterSections (sections) {
       return sections.filter((section) => {
         return section.deletedAt === ''
       })
     },
-    filterHiddenTasks (tasks) {
+    filterTasks (tasks) {
       return tasks.filter((task) => {
         return task.completedAt === '' & task.deletedAt === ''
       })

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -18,10 +18,10 @@
                                 @openTaskDetailModal="openTaskDetailModal")
               el-collapse-item(v-for="section in sectionList", :key="section.id", :title="section.label", :name="section.id", :disabled="judgeToEdit(section.id)")
                 template(slot="title")
-                  .pt-100
-                    j-move-icon
+                  j-move-icon
                   .section-title-area
                     el-input(v-model="section.label", @click.native="editSectionTitle(section.id)", @blur="editingSectionId = ''", size="medium", :class="{ 'is-editing': judgeToEdit(section.id) }")
+                  j-icon-button(genre="far", value="trash-alt", @click="deleteSection")
                 task-table.mt-100(:data="filterHiddenTasks(tableData[section.value])",
                                   :columns="columnList",
                                   :sectionValue="section.value",
@@ -38,15 +38,13 @@ import draggable from 'vuedraggable'
 import ContentHeader from '@/components/organisms/ContentHeader'
 import TaskDetailModal from '@/components/organisms/TaskDetailModal'
 import TaskTable from '@/components/molecules/TaskTable'
-import JMoveIcon from '@/components/atoms/JMoveIcon'
 
 export default {
   components: {
     draggable,
     ContentHeader,
     TaskDetailModal,
-    TaskTable,
-    JMoveIcon
+    TaskTable
   },
   data () {
     return {
@@ -190,6 +188,9 @@ export default {
       targetTask.deletedAt = Date()
       this.taskTotalNumber -= 1
       this.showTaskDetailModal = false
+    },
+    deleteSection () {
+
     },
     switchLiked (taskId, sectionValue) {
       const targetTask = this.tableData[sectionValue].find((task) => {

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -11,7 +11,7 @@
         el-main
           el-collapse(v-model="activeSections")
             draggable
-              task-table.mb-500(:data="filterCompletedTasks(tableData.notSectioned)",
+              task-table.mb-500(:data="filterHiddenTasks(tableData.notSectioned)",
                                 :columns="columnList",
                                 @completeTask="completeTask",
                                 @switchLiked="switchLiked",
@@ -22,7 +22,7 @@
                     JMoveIcon
                   .section-title-area
                     el-input(v-model="section.label", @click.native="editSectionTitle(section.id)", @blur="editingSectionId = ''", size="medium", :class="{ 'is-editing': judgeToEdit(section.id) }")
-                task-table.mt-100(:data="filterCompletedTasks(tableData[section.value])",
+                task-table.mt-100(:data="filterHiddenTasks(tableData[section.value])",
                                   :columns="columnList",
                                   :sectionValue="section.value",
                                   @completeTask="completeTask",
@@ -30,7 +30,7 @@
                                   @openTaskDetailModal="openTaskDetailModal")
       transition(name="task-detail-modal")
         .task-detail-modal-area(v-if="showTaskDetailModal")
-          task-detail-modal(:task="taskDetailModalContent", :sectionValue="taskDetailModalSectionValue", :columnList="columnList", @completeTask="completeTask", @switchLiked="switchLiked", @closeTaskDetailModal="closeTaskDetailModal")
+          task-detail-modal(:task="taskDetailModalContent", :sectionValue="taskDetailModalSectionValue", :columnList="columnList", @completeTask="completeTask", @deleteTask="deleteTask", @switchLiked="switchLiked", @closeTaskDetailModal="closeTaskDetailModal")
 </template>
 
 <script>
@@ -68,6 +68,7 @@ export default {
         notSectioned: [{
             id: 1,
             completedAt: '',
+            deletedAt: '',
             liked: false,
             data: {
               name: 'JavaScriptの勉強',
@@ -80,6 +81,7 @@ export default {
         section1: [{
           id: 2,
           completedAt: '',
+          deletedAt: '',
           liked: false,
           data: {
             name: 'タスクの表示/追加/名前変更機能',
@@ -91,6 +93,7 @@ export default {
         }, {
           id: 3,
           completedAt: '',
+          deletedAt: '',
           liked: false,
           data: {
             name: 'セクションの表示/追加/名前変更機能',
@@ -102,6 +105,7 @@ export default {
         }, {
           id: 4,
           completedAt: '',
+          deletedAt: '',
           liked: false,
           data: {
             name: 'セクションとタスクの紐付け',
@@ -114,6 +118,7 @@ export default {
         section2: [{
           id: 5,
           completedAt: '',
+          deletedAt: '',
           liked: false,
           data: {
             name: 'タスクへのいいね機能',
@@ -125,6 +130,7 @@ export default {
         }, {
           id: 6,
           completedAt: '',
+          deletedAt: '',
           liked: false,
           data: {
             name: 'タスクの削除',
@@ -162,9 +168,9 @@ export default {
     judgeToEdit (id) {
       return id === this.editingSectionId
     },
-    filterCompletedTasks (tasks) {
+    filterHiddenTasks (tasks) {
       return tasks.filter((task) => {
-        return task.completedAt === ''
+        return task.completedAt === '' & task.deletedAt === ''
       })
     },
     completeTask (taskId, sectionValue) {
@@ -176,6 +182,14 @@ export default {
       if (taskId === this.taskDetailModalContent.id) {
         this.showTaskDetailModal = false
       }
+    },
+    deleteTask (taskId, sectionValue) {
+      const targetTask = this.tableData[sectionValue].find((task) => {
+        return task.id === taskId
+      })
+      targetTask.deletedAt = Date()
+      this.taskTotalNumber -= 1
+      this.showTaskDetailModal = false
     },
     switchLiked (taskId, sectionValue) {
       const targetTask = this.tableData[sectionValue].find((task) => {


### PR DESCRIPTION
## 概要
- タスク/セクションの削除をできるように
- 削除からの復活は実装しません

## 技術的変更点概要
- タスク/セクションに対してdeletedかどうかのフィルターを通してからtableDataに渡すようにした

## 使い方
- タスク詳細モーダルの右上の削除ボタンでタスクの削除ができる
- セクションのタイトル右の削除ボタンでセクションの削除ができる
![dd6401cc3d5fe90ef53394b364876432](https://user-images.githubusercontent.com/38747501/81389479-da104080-9154-11ea-8407-f5704e41a7c2.gif)

## UIに対する変更
- 変更後のスクリーンショット
![image](https://user-images.githubusercontent.com/38747501/81389748-44c17c00-9155-11ea-89e4-95dcbc696722.png)

- 変更前のスクリーンショット
![スクリーンショット 2020-05-08 15 55 38](https://user-images.githubusercontent.com/38747501/81379622-67976480-9144-11ea-8ced-5263f7e16f78.png)

## テスト結果とテスト項目
- [x] タスクの削除ボタンを押すとタスクが非表示になる
- [x] セクションの削除ボタンを押すと確認のモーダルが出る
- [x] 確認のモーダルで削除ボタンを押すとセクションとそれに紐付いたタスクが非表示になる
- [x] 確認のモーダルでキャンセルボタンを押すと何も起きない

## 今回保留した項目とTODOリスト
- 特になし

## その他
- これもすぐ出来ました😊
- 削除タスクの表示や復活機能の実装は迷いましたが、本研修では対象外と考えてスキップしました

## 関連URL
- 研修の目的
https://smartcamp.kibe.la/notes/3813
- スケジュール
https://smartcamp.kibe.la/notes/3816