### PR TITLE
[XC]フィールドの表示（リストとタスク詳細両方）、各フィールドの表示・非表示切り替え

### DIFF
--- a/src/components/atoms/JSwitch.vue
+++ b/src/components/atoms/JSwitch.vue
@@ -1,0 +1,21 @@
+<template lang="pug">
+  el-switch(v-model="internalValue")
+</template>
+
+<script>
+export default {
+  props: {
+    value: Boolean
+  },
+  computed: {
+    internalValue: {
+      get () {
+        return this.value
+      },
+      set (newVal) {
+        this.$emit('input', newVal)
+      }
+    }
+  }
+}
+</script>

--- a/src/components/organisms/ContentHeader.vue
+++ b/src/components/organisms/ContentHeader.vue
@@ -1,10 +1,13 @@
 <template lang="pug">
   div
-    el-button(@click="addSection", icon="el-icon-plus", size="mini") セクションを追加
-    el-button.ml-100(@click="addTask", :disabled="existEmptyTask", icon="el-icon-plus", size="mini") タスクを追加
-    el-select.ml-100(v-model="selectedSectionValue", :disabled="existEmptyTask", placeholder="セクションを選択", size="mini", clearable)
-      el-option(v-for="section in sectionList", :key="section.id", :label="section.label", :value="section.value")
-    el-tag.ml-100(v-if="existEmptyTask", size="small", type="danger", effect="plain") 空のタスクが存在します
+    span.add-action-space
+      el-button(@click="addSection", icon="el-icon-plus", size="mini") セクションを追加
+      el-button.ml-100(@click="addTask", :disabled="existEmptyTask", icon="el-icon-plus", size="mini") タスクを追加
+      el-select.ml-100(v-model="selectedSectionValue", :disabled="existEmptyTask", placeholder="セクションを選択", size="mini", clearable)
+        el-option(v-for="section in sectionList", :key="section.id", :label="section.label", :value="section.value")
+      el-tag.ml-100(v-if="existEmptyTask", size="small", type="danger", effect="plain") 空のタスクが存在します
+    span.edit-action-space
+      el-button(@click="", icon="el-icon-notebook-2", size="mini") フィールドを編集
 </template>
 
 <script>
@@ -73,3 +76,9 @@ export default {
   }
 }
 </script>
+
+<style lang="scss" scoped>
+  .edit-action-space {
+    float: right;
+  }
+</style>

--- a/src/components/organisms/ContentHeader.vue
+++ b/src/components/organisms/ContentHeader.vue
@@ -11,9 +11,9 @@
         span(class="el-dropdown-link")
           el-button(icon="el-icon-notebook-2", size="mini") フィールドを編集
         el-dropdown-menu(slot="dropdown")
-          .field-item(v-for="column in columns")
-            el-switch
-            el-dropdown-item {{ column.label }}
+          .field-item.px-100(v-for="column in columns")
+            el-dropdown-item.column-label {{ column.label }}
+            el-switch.mx-200(v-model="column.visible")
 </template>
 
 <script>
@@ -96,5 +96,8 @@ export default {
   .field-item {
     display: flex;
     align-items: center;
+  }
+  .column-label {
+    width: 100%;
   }
 </style>

--- a/src/components/organisms/ContentHeader.vue
+++ b/src/components/organisms/ContentHeader.vue
@@ -7,7 +7,11 @@
         el-option(v-for="section in sectionList", :key="section.id", :label="section.label", :value="section.value")
       el-tag.ml-100(v-if="existEmptyTask", size="small", type="danger", effect="plain") 空のタスクが存在します
     span.edit-action-space
-      el-button(@click="", icon="el-icon-notebook-2", size="mini") フィールドを編集
+      el-dropdown(trigger="click")
+        span(class="el-dropdown-link")
+          el-button(icon="el-icon-notebook-2", size="mini") フィールドを編集
+        el-dropdown-menu(slot="dropdown")
+          el-dropdown-item(v-for="column in columns") {{ column.label }}
 </template>
 
 <script>
@@ -28,6 +32,12 @@ export default {
     taskTotalNumber: {
       type: Number,
       default: 0
+    },
+    columns: {
+      type: Array,
+      default: function () {
+        return []
+      }
     }
   },
   data () {

--- a/src/components/organisms/ContentHeader.vue
+++ b/src/components/organisms/ContentHeader.vue
@@ -13,7 +13,7 @@
         el-dropdown-menu(slot="dropdown")
           .field-item.px-100(v-for="column in columns", v-if="column.id !== 1")
             el-dropdown-item.column-label {{ column.label }}
-            el-switch.mx-200(v-model="column.visible")
+            j-switch.mx-200(v-model="column.visible")
 </template>
 
 <script>

--- a/src/components/organisms/ContentHeader.vue
+++ b/src/components/organisms/ContentHeader.vue
@@ -11,7 +11,7 @@
         span(class="el-dropdown-link")
           el-button(icon="el-icon-notebook-2", size="mini") フィールドを編集
         el-dropdown-menu(slot="dropdown")
-          .field-item.px-100(v-for="column in columns")
+          .field-item.px-100(v-for="column in columns", v-if="column.id !== 1")
             el-dropdown-item.column-label {{ column.label }}
             el-switch.mx-200(v-model="column.visible")
 </template>

--- a/src/components/organisms/ContentHeader.vue
+++ b/src/components/organisms/ContentHeader.vue
@@ -11,7 +11,9 @@
         span(class="el-dropdown-link")
           el-button(icon="el-icon-notebook-2", size="mini") フィールドを編集
         el-dropdown-menu(slot="dropdown")
-          el-dropdown-item(v-for="column in columns") {{ column.label }}
+          .field-item(v-for="column in columns")
+            el-switch
+            el-dropdown-item {{ column.label }}
 </template>
 
 <script>
@@ -90,5 +92,9 @@ export default {
 <style lang="scss" scoped>
   .edit-action-space {
     float: right;
+  }
+  .field-item {
+    display: flex;
+    align-items: center;
   }
 </style>

--- a/src/components/organisms/TaskTable.vue
+++ b/src/components/organisms/TaskTable.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
   div.pl-600
-    template(v-for="(column, index) in columns")
+    template(v-for="(column, index) in filterdColumns")
       el-input.header(v-model="column.label", :style="{ width: column.width + 'px' }", readonly)
       span(v-if="index === 0")
         .task-action-space-all
@@ -8,7 +8,7 @@
       transition-group(name="task-table", tag="div")
         .task-table-item(v-for="task in tasks", :key="task.id")
           j-task-line(:task="task",
-                      :columns="columns",
+                      :columns="filterdColumns",
                       @completeTask="completeTask",
                       @switchVisibleSubtasks="switchVisibleSubtasks",
                       @switchLiked="switchLiked",
@@ -16,7 +16,7 @@
           transition-group(name="subtask-table", tag="div")
             .subtask-table-item(v-if="task.visibleSubtasks", v-for="subtask in filterSubtasks(task.subtasks)", :key="subtask.id")
               j-task-line(:task="subtask",
-                          :columns="columns",
+                          :columns="filterdColumns",
                           type="subtask",
                           @completeTask="completeTask",
                           @switchLiked="switchLiked",
@@ -40,6 +40,13 @@ export default {
     columns: {
       type: Array,
       required: true
+    }
+  },
+  computed: {
+    filterdColumns () {
+      return this.columns.filter((column) => {
+        return column.visible
+      })
     }
   },
   methods: {

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -63,11 +63,11 @@ export default {
   data () {
     return {
       columnList: [
-        { id: 1, label: 'タスク名', value: 'name', width: 240 },
-        { id: 2, label: '担当者', value: 'person', width: 100 },
-        { id: 3, label: '期日', value: 'deadline', width: 100 },
-        { id: 4, label: 'タグ', value: 'tag', width: 100 },
-        { id: 5, label: 'その他', value: 'other', width: 100 }
+        { id: 1, label: 'タスク名', value: 'name', width: 240, visible: true },
+        { id: 2, label: '担当者', value: 'person', width: 100, visible: true },
+        { id: 3, label: '期日', value: 'deadline', width: 100, visible: true },
+        { id: 4, label: 'タグ', value: 'tag', width: 100, visible: true },
+        { id: 5, label: 'その他', value: 'other', width: 100, visible: false }
       ],
       sectionList: [
         { id: 1, deletedAt: '', label: '4/15~29のタスク', value: 'section1' },

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -6,7 +6,12 @@
     el-main
       el-container
         el-header(height="28px")
-          content-header(:sectionList="filterSections(sectionList)", :tableData="tableData", :taskTotalNumber="taskTotalNumber", @addTask="addTask", @addSection="addSection")
+          content-header(:sectionList="filterSections(sectionList)",
+                         :tableData="tableData",
+                         :taskTotalNumber="taskTotalNumber",
+                         :columns="columnList",
+                         @addTask="addTask",
+                         @addSection="addSection")
         el-main
           el-collapse(v-model="activeSections")
             draggable

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,7 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 
 import App from './App.vue'
 import JIconButton from '@/components/atoms/JIconButton'
+import JSwitch from '@/components/atoms/JSwitch'
 import JTaskLine from '@/components/molecules/JTaskLine'
 
 library.add(fas, far, fab)
@@ -19,6 +20,7 @@ Vue.config.productionTip = false
 Vue.use(ElementUI, { locale })
 Vue.component('font-awesome-icon', FontAwesomeIcon)
 Vue.component('j-icon-button', JIconButton)
+Vue.component('j-switch', JSwitch)
 Vue.component('j-task-line', JTaskLine)
 
 new Vue({


### PR DESCRIPTION
## 概要
- フィールド（タスクの「タスク名」以外の項目）の表示/非表示切り替え

## 技術的変更点概要
- visible:trueのフィールドのみ表示されるようにデータ構造やデータ表示部分を変更
- JSwitchの切り出し

## 使い方
- ホーム画面ヘッダー右の「フィールドを編集」ボタンからフィールドごとに切り替え
![45197290441f91167f3e8d88548d0bec](https://user-images.githubusercontent.com/38747501/81895989-8a1af900-95ee-11ea-9b86-222ef7a8dc1a.gif)

## UIに対する変更
- 変更後のスクリーンショット
![image](https://user-images.githubusercontent.com/38747501/81896023-9d2dc900-95ee-11ea-8d8e-0eac4c64d15f.png)

- 変更前のスクリーンショット
![image](https://user-images.githubusercontent.com/38747501/81778584-1e715700-952e-11ea-9927-88d8429fc8fb.png)

## テスト結果とテスト項目
- [x] 切り替えボタンでフィールドの表示/非表示が切り替えられる
- [x] 切り替えボタンで非表示にしても、タスク詳細モーダル内では非表示にならない

## 今回保留した項目とTODOリスト
- 特になし

## その他
- さくっと出来ました😊
- Vue.jsや開発の為のドキュメント検索に少し慣れてきた気がします

## 関連URL
- 研修の目的
https://smartcamp.kibe.la/notes/3813
- スケジュール
https://smartcamp.kibe.la/notes/3816