### PR TITLE
[XC]フィールドの追加、変更、削除

### DIFF
--- a/src/components/atoms/JModal.vue
+++ b/src/components/atoms/JModal.vue
@@ -1,0 +1,29 @@
+<template functional lang="pug">
+  .overlay
+    .window
+      .contents
+        slot
+</template>
+
+<style lang="scss" scoped>
+  .overlay {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: fixed;
+    z-index: 100;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+  }
+  .window {
+    background: $bgcolor-base;
+    border-radius: 4px;
+    overflow: hidden;
+  }
+  .contents {
+    padding: $basespace-100 $basespace-200;
+  }
+</style>

--- a/src/components/atoms/JModal.vue
+++ b/src/components/atoms/JModal.vue
@@ -1,9 +1,19 @@
-<template functional lang="pug">
-  .overlay
+<template lang="pug">
+  .overlay(@click.self="closeModal")
     .window
       .contents
         slot
 </template>
+
+<script>
+export default {
+  methods: {
+    closeModal () {
+      this.$emit('closeModal')
+    }
+  }
+}
+</script>
 
 <style lang="scss" scoped>
   .overlay {

--- a/src/components/atoms/JModal.vue
+++ b/src/components/atoms/JModal.vue
@@ -1,6 +1,9 @@
 <template lang="pug">
   .overlay(@click.self="closeModal")
     .window
+      .header
+        slot(name="header")
+      hr
       .contents
         slot
 </template>
@@ -33,7 +36,10 @@ export default {
     border-radius: 4px;
     overflow: hidden;
   }
+  .header {
+    padding: $basespace-200 $basespace-400;
+  }
   .contents {
-    padding: $basespace-100 $basespace-200;
+    padding: $basespace-200 $basespace-400;
   }
 </style>

--- a/src/components/atoms/JModal.vue
+++ b/src/components/atoms/JModal.vue
@@ -37,6 +37,8 @@ export default {
     overflow: hidden;
   }
   .header {
+    display: flex;
+    align-items: center;
     padding: $basespace-200 $basespace-400;
   }
   .contents {

--- a/src/components/molecules/JTaskLine.vue
+++ b/src/components/molecules/JTaskLine.vue
@@ -6,7 +6,7 @@
     .task-action-space
       j-icon-button(genre="far", value="check-circle", hover-color="success", @click="completeTask")
     template(v-for="(column, index) in columns")
-      el-input(v-model="task.data[column.value]", :style="{ width: column.width + 'px' }")
+      el-input(v-model="task.data[column.keyName]", :style="{ width: column.width + 'px' }")
       span(v-if="index === 0")
         .task-action-space(v-if="type === 'task'")
           div(v-if="filterSubtasks(task.subtasks).length > 0")

--- a/src/components/organisms/ContentHeader.vue
+++ b/src/components/organisms/ContentHeader.vue
@@ -29,7 +29,7 @@
           el-input(v-model="selectedField.width")
         .field-item.py-100
           .column-label フィールドタイプ
-          el-input
+          el-input(v-model="selectedField.type", disabled)
 </template>
 
 <script>
@@ -109,6 +109,7 @@ export default {
         id: emptyFieldId,
         label: '未設定',
         value: 'field' + emptyFieldId,
+        type: '文字列',
         width: 100,
         visible: true
       }

--- a/src/components/organisms/ContentHeader.vue
+++ b/src/components/organisms/ContentHeader.vue
@@ -17,8 +17,11 @@
           hr.my-100
           .field-item
             el-button(@click="addField", icon="el-icon-plus", size="mini", type="text") フィールドを追加
-    j-modal(v-if="visibleFieldModal", @closeModal="closeModal")
-      .edit-field-modal {{ selectedField }}
+    j-modal(v-if="visibleFieldModal", @closeModal="closeFieldModal")
+      template(v-slot:header)
+        div へっだー
+      template
+        div {{ selectedField }}
 </template>
 
 <script>
@@ -107,7 +110,7 @@ export default {
       this.selectedField = field
       this.visibleFieldModal = true
     },
-    closeModal () {
+    closeFieldModal () {
       this.visibleFieldModal = false
       this.selectedField = {}
     }

--- a/src/components/organisms/ContentHeader.vue
+++ b/src/components/organisms/ContentHeader.vue
@@ -14,6 +14,9 @@
           .field-item.px-100(v-for="column in columns", v-if="column.id !== 1")
             el-dropdown-item.column-label {{ column.label }}
             el-switch.mx-200(v-model="column.visible")
+          hr
+          .field-item
+            el-button.mt-200(@click="addField", icon="el-icon-plus", size="mini", type="text") フィールドを追加
 </template>
 
 <script>
@@ -84,6 +87,9 @@ export default {
     },
     addSection () {
       this.$emit('addSection')
+    },
+    addField () {
+
     }
   }
 }
@@ -95,6 +101,7 @@ export default {
   }
   .field-item {
     display: flex;
+    justify-content: center;
     align-items: center;
   }
   .column-label {

--- a/src/components/organisms/ContentHeader.vue
+++ b/src/components/organisms/ContentHeader.vue
@@ -7,12 +7,12 @@
         el-option(v-for="section in sectionList", :key="section.id", :label="section.label", :value="section.value")
       el-tag.ml-100(v-if="existEmptyTask", size="small", type="danger", effect="plain") 空のタスクが存在します
     span.edit-action-space
-      el-dropdown(trigger="click")
+      el-dropdown(trigger="click", @command="handleCommand")
         span(class="el-dropdown-link")
           el-button(icon="el-icon-notebook-2", size="mini") フィールドを編集
         el-dropdown-menu(slot="dropdown")
           .field-item.px-100(v-for="column in columns", v-if="column.id !== 1")
-            el-dropdown-item.column-label {{ column.label }}
+            el-dropdown-item(:command="column.value").column-label {{ column.label }}
             el-switch.mx-200(v-model="column.visible")
           hr.my-100
           .field-item
@@ -98,6 +98,9 @@ export default {
         visible: true
       }
       this.$emit('addField', emptyField)
+    },
+    handleCommand(command) {
+      this.$message('click on item ' + command)
     }
   }
 }

--- a/src/components/organisms/ContentHeader.vue
+++ b/src/components/organisms/ContentHeader.vue
@@ -13,7 +13,7 @@
         el-dropdown-menu(slot="dropdown")
           .field-item.px-100(v-for="column in columns", v-if="column.id !== 1")
             el-dropdown-item(:command="column").column-label {{ column.label }}
-            el-switch.mx-200(v-model="column.visible")
+            j-switch.mx-200(v-model="column.visible")
           hr.my-100
           .field-item
             el-button(@click="addField", icon="el-icon-plus", size="mini", type="text") フィールドを追加
@@ -31,8 +31,6 @@
         .field-item.py-100
           .column-label フィールドタイプ
           el-input(v-model="selectedField.typeLabel", disabled)
-            el-dropdown-item.column-label {{ column.label }}
-            j-switch.mx-200(v-model="column.visible")
 </template>
 
 <script>

--- a/src/components/organisms/ContentHeader.vue
+++ b/src/components/organisms/ContentHeader.vue
@@ -89,7 +89,15 @@ export default {
       this.$emit('addSection')
     },
     addField () {
-
+      const emptyFieldId = this.columns.length + 1
+      const emptyField = {
+        id: emptyFieldId,
+        label: '',
+        value: 'field' + emptyFieldId,
+        width: 100,
+        visible: true
+      }
+      this.$emit('addField', emptyField)
     }
   }
 }

--- a/src/components/organisms/ContentHeader.vue
+++ b/src/components/organisms/ContentHeader.vue
@@ -14,9 +14,9 @@
           .field-item.px-100(v-for="column in columns", v-if="column.id !== 1")
             el-dropdown-item.column-label {{ column.label }}
             el-switch.mx-200(v-model="column.visible")
-          hr.mt-100
+          hr.my-100
           .field-item
-            el-button.mt-200(@click="addField", icon="el-icon-plus", size="mini", type="text") フィールドを追加
+            el-button(@click="addField", icon="el-icon-plus", size="mini", type="text") フィールドを追加
 </template>
 
 <script>

--- a/src/components/organisms/ContentHeader.vue
+++ b/src/components/organisms/ContentHeader.vue
@@ -17,7 +17,7 @@
           hr.my-100
           .field-item
             el-button(@click="addField", icon="el-icon-plus", size="mini", type="text") フィールドを追加
-    j-modal
+    j-modal(v-if="visibleFieldModal", @closeModal="closeModal")
       .edit-field-modal モーダルだよ
 </template>
 
@@ -49,7 +49,8 @@ export default {
   },
   data () {
     return {
-      selectedSectionValue: ''
+      selectedSectionValue: '',
+      visibleFieldModal: true
     }
   },
   computed: {
@@ -101,8 +102,11 @@ export default {
       }
       this.$emit('addField', emptyField)
     },
-    handleCommand(command) {
+    handleCommand (command) {
       this.$message('click on item ' + command)
+    },
+    closeModal () {
+      this.visibleFieldModal = false
     }
   }
 }

--- a/src/components/organisms/ContentHeader.vue
+++ b/src/components/organisms/ContentHeader.vue
@@ -19,9 +19,17 @@
             el-button(@click="addField", icon="el-icon-plus", size="mini", type="text") フィールドを追加
     j-modal(v-if="visibleFieldModal", @closeModal="closeFieldModal")
       template(v-slot:header)
-        div へっだー
+        .fw-bold 「{{ selectedField.label }}」フィールドの編集
       template
-        div {{ selectedField }}
+        .field-item.py-100
+          .column-label フィールド名
+          el-input(v-model="selectedField.label")
+        .field-item.py-100
+          .column-label フィールドの幅(px)
+          el-input(v-model="selectedField.width")
+        .field-item.py-100
+          .column-label フィールドタイプ
+          el-input
 </template>
 
 <script>

--- a/src/components/organisms/ContentHeader.vue
+++ b/src/components/organisms/ContentHeader.vue
@@ -17,6 +17,8 @@
           hr.my-100
           .field-item
             el-button(@click="addField", icon="el-icon-plus", size="mini", type="text") フィールドを追加
+    j-modal
+      .edit-field-modal モーダルだよ
 </template>
 
 <script>

--- a/src/components/organisms/ContentHeader.vue
+++ b/src/components/organisms/ContentHeader.vue
@@ -7,18 +7,18 @@
         el-option(v-for="section in sectionList", :key="section.id", :label="section.label", :value="section.value")
       el-tag.ml-100(v-if="existEmptyTask", size="small", type="danger", effect="plain") 空のタスクが存在します
     span.edit-action-space
-      el-dropdown(trigger="click", @command="handleCommand")
+      el-dropdown(trigger="click", @command="openFieldModal")
         span(class="el-dropdown-link")
           el-button(icon="el-icon-notebook-2", size="mini") フィールドを編集
         el-dropdown-menu(slot="dropdown")
           .field-item.px-100(v-for="column in columns", v-if="column.id !== 1")
-            el-dropdown-item(:command="column.value").column-label {{ column.label }}
+            el-dropdown-item(:command="column").column-label {{ column.label }}
             el-switch.mx-200(v-model="column.visible")
           hr.my-100
           .field-item
             el-button(@click="addField", icon="el-icon-plus", size="mini", type="text") フィールドを追加
     j-modal(v-if="visibleFieldModal", @closeModal="closeModal")
-      .edit-field-modal モーダルだよ
+      .edit-field-modal {{ selectedField }}
 </template>
 
 <script>
@@ -50,7 +50,8 @@ export default {
   data () {
     return {
       selectedSectionValue: '',
-      visibleFieldModal: true
+      visibleFieldModal: false,
+      selectedField: {}
     }
   },
   computed: {
@@ -102,11 +103,13 @@ export default {
       }
       this.$emit('addField', emptyField)
     },
-    handleCommand (command) {
-      this.$message('click on item ' + command)
+    openFieldModal (field) {
+      this.selectedField = field
+      this.visibleFieldModal = true
     },
     closeModal () {
       this.visibleFieldModal = false
+      this.selectedField = {}
     }
   }
 }

--- a/src/components/organisms/ContentHeader.vue
+++ b/src/components/organisms/ContentHeader.vue
@@ -4,7 +4,7 @@
       el-button(@click="addSection", icon="el-icon-plus", size="mini") セクションを追加
       el-button.ml-100(@click="addTask", :disabled="existEmptyTask", icon="el-icon-plus", size="mini") タスクを追加
       el-select.ml-100(v-model="selectedSectionValue", :disabled="existEmptyTask", placeholder="セクションを選択", size="mini", clearable)
-        el-option(v-for="section in sectionList", :key="section.id", :label="section.label", :value="section.value")
+        el-option(v-for="section in sectionList", :key="section.id", :label="section.label | truncate(15)", :value="section.value")
       el-tag.ml-100(v-if="existEmptyTask", size="small", type="danger", effect="plain") 空のタスクが存在します
     span.edit-action-space
       el-dropdown(trigger="click", @command="openFieldModal")
@@ -12,7 +12,7 @@
           el-button(icon="el-icon-notebook-2", size="mini") フィールドを編集
         el-dropdown-menu(slot="dropdown")
           .field-item.px-100(v-for="column in columns", v-if="column.id !== 1")
-            el-dropdown-item(:command="column").column-label {{ column.label }}
+            el-dropdown-item(:command="column").column-label {{ column.label | truncate }}
             j-switch.mx-200(v-model="column.visible")
           hr.my-100
           .field-item
@@ -113,7 +113,7 @@ export default {
         value: 'field' + emptyFieldId,
         typeLabel: '文字列',
         typeValue: 'string',
-        width: 100,
+        width: 120,
         visible: true
       }
       this.$emit('addField', emptyField)

--- a/src/components/organisms/ContentHeader.vue
+++ b/src/components/organisms/ContentHeader.vue
@@ -29,7 +29,7 @@
           el-input(v-model="selectedField.width")
         .field-item.py-100
           .column-label フィールドタイプ
-          el-input(v-model="selectedField.type", disabled)
+          el-input(v-model="selectedField.typeLabel", disabled)
 </template>
 
 <script>
@@ -109,7 +109,8 @@ export default {
         id: emptyFieldId,
         label: '未設定',
         value: 'field' + emptyFieldId,
-        type: '文字列',
+        typeLabel: '文字列',
+        typeValue: 'string',
         width: 100,
         visible: true
       }

--- a/src/components/organisms/ContentHeader.vue
+++ b/src/components/organisms/ContentHeader.vue
@@ -92,7 +92,7 @@ export default {
       const emptyFieldId = this.columns.length + 1
       const emptyField = {
         id: emptyFieldId,
-        label: '',
+        label: '未設定',
         value: 'field' + emptyFieldId,
         width: 100,
         visible: true

--- a/src/components/organisms/ContentHeader.vue
+++ b/src/components/organisms/ContentHeader.vue
@@ -19,7 +19,7 @@
             el-button(@click="addField", icon="el-icon-plus", size="mini", type="text") フィールドを追加
     j-modal(v-if="visibleFieldModal", @closeModal="closeFieldModal")
       template(v-slot:header)
-        .fw-bold 「{{ selectedField.label }}」フィールドの編集
+        .fw-bold 「{{ selectedField.label | truncate }}」フィールドの編集
         j-icon-button.ml-a(genre="far", value="trash-alt", @click="deleteField")
       template
         .field-item.py-100

--- a/src/components/organisms/ContentHeader.vue
+++ b/src/components/organisms/ContentHeader.vue
@@ -14,7 +14,7 @@
           .field-item.px-100(v-for="column in columns", v-if="column.id !== 1")
             el-dropdown-item.column-label {{ column.label }}
             el-switch.mx-200(v-model="column.visible")
-          hr
+          hr.mt-100
           .field-item
             el-button.mt-200(@click="addField", icon="el-icon-plus", size="mini", type="text") フィールドを追加
 </template>

--- a/src/components/organisms/ContentHeader.vue
+++ b/src/components/organisms/ContentHeader.vue
@@ -27,7 +27,7 @@
           el-input(v-model="selectedField.label")
         .field-item.py-100
           .column-label フィールドの幅(px)
-          el-input(v-model="selectedField.width")
+          el-input(v-model.number="selectedField.width")
         .field-item.py-100
           .column-label フィールドタイプ
           el-input(v-model="selectedField.typeLabel", disabled)

--- a/src/components/organisms/ContentHeader.vue
+++ b/src/components/organisms/ContentHeader.vue
@@ -119,7 +119,8 @@ export default {
       this.$emit('addField', emptyField)
     },
     deleteField () {
-      this.$emit('deleteField', this.selectedField)
+      this.$emit('deleteField', this.selectedField.value)
+      this.closeFieldModal()
     },
     openFieldModal (field) {
       this.selectedField = field

--- a/src/components/organisms/ContentHeader.vue
+++ b/src/components/organisms/ContentHeader.vue
@@ -109,13 +109,14 @@ export default {
       const emptyField = {
         id: emptyFieldId,
         deletedAt: '',
-        label: '未設定',
+        label: '（未設定）',
         keyName: 'field' + emptyFieldId,
         typeLabel: '文字列',
         typeValue: 'string',
         width: 120,
         visible: true
       }
+      this.openFieldModal(emptyField)
       this.$emit('addField', emptyField)
     },
     deleteField () {

--- a/src/components/organisms/ContentHeader.vue
+++ b/src/components/organisms/ContentHeader.vue
@@ -20,6 +20,7 @@
     j-modal(v-if="visibleFieldModal", @closeModal="closeFieldModal")
       template(v-slot:header)
         .fw-bold 「{{ selectedField.label }}」フィールドの編集
+        j-icon-button.ml-a(genre="far", value="trash-alt", @click="deleteField")
       template
         .field-item.py-100
           .column-label フィールド名
@@ -107,6 +108,7 @@ export default {
       const emptyFieldId = this.columns.length + 1
       const emptyField = {
         id: emptyFieldId,
+        deletedAt: '',
         label: '未設定',
         value: 'field' + emptyFieldId,
         typeLabel: '文字列',
@@ -115,6 +117,9 @@ export default {
         visible: true
       }
       this.$emit('addField', emptyField)
+    },
+    deleteField () {
+      this.$emit('deleteField', this.selectedField)
     },
     openFieldModal (field) {
       this.selectedField = field

--- a/src/components/organisms/ContentHeader.vue
+++ b/src/components/organisms/ContentHeader.vue
@@ -4,7 +4,7 @@
       el-button(@click="addSection", icon="el-icon-plus", size="mini") セクションを追加
       el-button.ml-100(@click="addTask", :disabled="existEmptyTask", icon="el-icon-plus", size="mini") タスクを追加
       el-select.ml-100(v-model="selectedSectionValue", :disabled="existEmptyTask", placeholder="セクションを選択", size="mini", clearable)
-        el-option(v-for="section in sectionList", :key="section.id", :label="section.label | truncate(15)", :value="section.value")
+        el-option(v-for="section in sectionList", :key="section.id", :label="section.label | truncate(15)", :value="section.keyName")
       el-tag.ml-100(v-if="existEmptyTask", size="small", type="danger", effect="plain") 空のタスクが存在します
     span.edit-action-space
       el-dropdown(trigger="click", @command="openFieldModal")
@@ -110,7 +110,7 @@ export default {
         id: emptyFieldId,
         deletedAt: '',
         label: '未設定',
-        value: 'field' + emptyFieldId,
+        keyName: 'field' + emptyFieldId,
         typeLabel: '文字列',
         typeValue: 'string',
         width: 120,
@@ -119,7 +119,7 @@ export default {
       this.$emit('addField', emptyField)
     },
     deleteField () {
-      this.$emit('deleteField', this.selectedField.value)
+      this.$emit('deleteField', this.selectedField.keyName)
       this.closeFieldModal()
     },
     openFieldModal (field) {

--- a/src/components/organisms/TaskDetailModal.vue
+++ b/src/components/organisms/TaskDetailModal.vue
@@ -14,7 +14,7 @@
       .fs-600.fw-bold.mb-400 {{ task.data[columnList[0].value] }}
       el-row.mb-200(v-for="column in columnList.slice(1)", :key="column.id")
         el-col.pt-100(:span="6")
-          span {{ column.label }}
+          span {{ column.label | truncate }}
         el-col(:span="18")
           el-input(v-model="task.data[column.value]")
       .mt-200(v-if="'subtasks' in task")

--- a/src/components/organisms/TaskDetailModal.vue
+++ b/src/components/organisms/TaskDetailModal.vue
@@ -11,12 +11,12 @@
         j-icon-button.mr-200(genre="fas", value="chevron-right", @click="closeTaskDetailModal")
     hr
     el-main
-      .fs-600.fw-bold.mb-400 {{ task.data[columnList[0].value] }}
+      .fs-600.fw-bold.mb-400 {{ task.data[columnList[0].keyName] }}
       el-row.mb-200(v-for="column in columnList.slice(1)", :key="column.id")
         el-col.pt-100(:span="6")
           span {{ column.label | truncate }}
         el-col(:span="18")
-          el-input(v-model="task.data[column.value]")
+          el-input(v-model="task.data[column.keyName]")
       .mt-200(v-if="'subtasks' in task")
         .mt-500(v-if="filterSubtasks(task.subtasks).length > 0")
           .mb-100 サブタスク

--- a/src/components/organisms/TaskTable.vue
+++ b/src/components/organisms/TaskTable.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
   div.pl-600
     template(v-for="(column, index) in filterdColumns")
-      el-input.header(v-model="column.label", :style="{ width: column.width + 'px' }", readonly)
+      el-input.header(:value="column.label | truncate", :style="{ width: column.width + 'px' }", readonly)
       span(v-if="index === 0")
         .task-action-space-all
     draggable(group="tasks")

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -21,11 +21,19 @@
                                 @completeTask="completeTask",
                                 @switchLiked="switchLiked",
                                 @openTaskDetailModal="openTaskDetailModal")
-              el-collapse-item(v-for="section in filterSections(sectionList)", :key="section.id", :title="section.label", :name="section.id", :disabled="judgeToEdit(section.id)")
+              el-collapse-item(v-for="section in filterSections(sectionList)",
+                               :key="section.id",
+                               :title="section.label",
+                               :name="section.id",
+                               :disabled="judgeToEdit(section.id)")
                 template(slot="title")
                   j-icon-button(genre="fas", value="grip-vertical", type="grab")
                   .section-title-area.ml-200
-                    el-input(v-model="section.label", @click.native="editSectionTitle(section.id)", @blur="editingSectionId = ''", size="medium", :class="{ 'is-editing': judgeToEdit(section.id) }")
+                    el-input(v-model="section.label",
+                             @click.native="editSectionTitle(section.id)",
+                             @blur="editingSectionId = ''",
+                             size="medium",
+                             :class="{ 'is-editing': judgeToEdit(section.id) }")
                   j-icon-button.ml-200(genre="far", value="trash-alt", @click.stop="deleteSection(section)")
                 task-table.mt-100(:tasks="filterTasks(tableData[section.value])",
                                   :columns="columnList",

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -71,10 +71,11 @@ export default {
         { id: 5, label: 'その他', value: 'other', width: 100, visible: false }
       ],
       sectionList: [
-        { id: 1, deletedAt: '', label: '4/15~29のタスク', value: 'section1' },
-        { id: 2, deletedAt: '', label: '5/04~20のタスク', value: 'section2' }
+        { id: 1, deletedAt: '', label: '', value: 'notSectioned' },
+        { id: 2, deletedAt: '', label: '4/15~29のタスク', value: 'section1' },
+        { id: 3, deletedAt: '', label: '5/04~20のタスク', value: 'section2' }
       ],
-      activeSections: [1, 2],
+      activeSections: [2, 3],
       editingSectionId: '',
       taskTotalNumber: 6,
       tableData: {
@@ -242,7 +243,7 @@ export default {
     },
     filterSections (sections) {
       return sections.filter((section) => {
-        return section.deletedAt === ''
+        return section.value !== 'notSectioned' && section.deletedAt === ''
       })
     },
     filterTasks (tasks) {

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -11,7 +11,8 @@
                          :taskTotalNumber="taskTotalNumber",
                          :columns="columnList",
                          @addTask="addTask",
-                         @addSection="addSection")
+                         @addSection="addSection",
+                         @addField="addField")
         el-main
           el-collapse(v-model="activeSections")
             draggable
@@ -224,6 +225,9 @@ export default {
     },
     addSubtask (task, subtask) {
       task.subtasks.push(subtask)
+    },
+    addField (field) {
+      this.columnList.push(field)
     },
     editSectionTitle (id) {
       this.editingSectionId = id

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -12,7 +12,8 @@
                          :columns="columnList",
                          @addTask="addTask",
                          @addSection="addSection",
-                         @addField="addField")
+                         @addField="addField",
+                         @deleteField="deleteField")
         el-main
           el-collapse(v-model="activeSections")
             draggable
@@ -71,11 +72,11 @@ export default {
   data () {
     return {
       columnList: [
-        { id: 1, label: 'タスク名', value: 'name', typeLabel: '文字列', typeValue: 'string', width: 240, visible: true },
-        { id: 2, label: '担当者', value: 'person', typeLabel: '文字列', typeValue: 'string', width: 100, visible: true },
-        { id: 3, label: '期日', value: 'deadline', typeLabel: '文字列', typeValue: 'string', width: 100, visible: true },
-        { id: 4, label: 'タグ', value: 'tag', typeLabel: '文字列', typeValue: 'string', width: 100, visible: true },
-        { id: 5, label: 'その他', value: 'other', typeLabel: '文字列', typeValue: 'string', width: 100, visible: false }
+        { id: 1, deletedAt: '', label: 'タスク名', value: 'name', typeLabel: '文字列', typeValue: 'string', width: 240, visible: true },
+        { id: 2, deletedAt: '', label: '担当者', value: 'person', typeLabel: '文字列', typeValue: 'string', width: 100, visible: true },
+        { id: 3, deletedAt: '', label: '期日', value: 'deadline', typeLabel: '文字列', typeValue: 'string', width: 100, visible: true },
+        { id: 4, deletedAt: '', label: 'タグ', value: 'tag', typeLabel: '文字列', typeValue: 'string', width: 100, visible: true },
+        { id: 5, deletedAt: '', label: 'その他', value: 'other', typeLabel: '文字列', typeValue: 'string', width: 100, visible: false }
       ],
       sectionList: [
         { id: 1, deletedAt: '', label: '', value: 'notSectioned' },
@@ -298,6 +299,10 @@ export default {
     deleteTask (task) {
       task.deletedAt = Date()
       this.showTaskDetailModal = false
+    },
+    deleteField (field) {
+      this.closeTaskDetailModal()
+      field.deletedAt = Date()
     },
     switchLiked (task) {
       if (task.liked) {

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -311,7 +311,25 @@ export default {
       const targetField = this.columnList.find((column) =>{
         return column.value === fieldValue
       })
-      targetField.deletedAt = Date()
+      this.$confirm(
+        '紐付いた値を含む「' + targetField.label + '」のすべてが削除されます。',
+        'フィールドを削除してもよろしいですか？',
+        {
+          confirmButtonText: 'フィールドを削除',
+          cancelButtonText: 'キャンセル',
+          type: 'warning'
+        }).then(() => {
+          this.$message({
+            type: 'success',
+            message: targetField.label + 'は削除されました'
+          })
+          targetField.deletedAt = Date()
+        }).catch(() => {
+          this.$message({
+            type: 'info',
+            message: '削除はキャンセルされました'
+          })
+        })
     },
     switchLiked (task) {
       if (task.liked) {

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -14,6 +14,7 @@
                          @addSection="addSection",
                          @addField="addField",
                          @deleteField="deleteField")
+        //- TODO: 横にはみ出た場合にスクロールできるように
         el-main
           el-collapse(v-model="activeSections")
             draggable

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -74,10 +74,10 @@ export default {
     return {
       columnList: [
         { id: 1, deletedAt: '', label: 'タスク名', value: 'name', typeLabel: '文字列', typeValue: 'string', width: 240, visible: true },
-        { id: 2, deletedAt: '', label: '担当者', value: 'person', typeLabel: '文字列', typeValue: 'string', width: 100, visible: true },
-        { id: 3, deletedAt: '', label: '期日', value: 'deadline', typeLabel: '文字列', typeValue: 'string', width: 100, visible: true },
-        { id: 4, deletedAt: '', label: 'タグ', value: 'tag', typeLabel: '文字列', typeValue: 'string', width: 100, visible: true },
-        { id: 5, deletedAt: '', label: 'その他', value: 'other', typeLabel: '文字列', typeValue: 'string', width: 100, visible: false }
+        { id: 2, deletedAt: '', label: '担当者', value: 'person', typeLabel: '文字列', typeValue: 'string', width: 120, visible: true },
+        { id: 3, deletedAt: '', label: '期日', value: 'deadline', typeLabel: '文字列', typeValue: 'string', width: 120, visible: true },
+        { id: 4, deletedAt: '', label: '機能の開発区分', value: 'tag', typeLabel: '文字列', typeValue: 'string', width: 120, visible: true },
+        { id: 5, deletedAt: '', label: 'その他', value: 'other', typeLabel: '文字列', typeValue: 'string', width: 120, visible: false }
       ],
       sectionList: [
         { id: 1, deletedAt: '', label: '', value: 'notSectioned' },

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -228,6 +228,11 @@ export default {
     },
     addField (field) {
       this.columnList.push(field)
+      this.sectionList.forEach((section) => {
+        this.tableData[section.value].forEach((task) => {
+          this.$set(task.data, field.value, '')
+        })
+      })
     },
     editSectionTitle (id) {
       this.editingSectionId = id

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -80,11 +80,10 @@ export default {
         { id: 5, deletedAt: '', label: 'その他', keyName: 'other', typeLabel: '文字列', typeValue: 'string', width: 120, visible: false }
       ],
       sectionList: [
-        { id: 1, deletedAt: '', label: '', keyName: 'notSectioned' },
-        { id: 2, deletedAt: '', label: '4/15~29のタスク', keyName: 'section1' },
-        { id: 3, deletedAt: '', label: '5/04~20のタスク', keyName: 'section2' }
+        { id: 1, deletedAt: '', label: '4/15~29のタスク', keyName: 'section1' },
+        { id: 2, deletedAt: '', label: '5/04~20のタスク', keyName: 'section2' }
       ],
-      activeSections: [2, 3],
+      activeSections: [1, 2],
       editingSectionId: '',
       taskTotalNumber: 6,
       subtaskTotalNumber: 3,
@@ -261,7 +260,7 @@ export default {
     },
     filterSections (sections) {
       return sections.filter((section) => {
-        return section.keyName !== 'notSectioned' && section.deletedAt === ''
+        return section.deletedAt === ''
       })
     },
     filterTasks (tasks) {

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -29,7 +29,6 @@
                   j-icon-button.ml-200(genre="far", value="trash-alt", @click.stop="deleteSection(section)")
                 task-table.mt-100(:tasks="filterTasks(tableData[section.value])",
                                   :columns="columnList",
-                                  :sectionValue="section.value",
                                   @completeTask="completeTask",
                                   @switchLiked="switchLiked",
                                   @openTaskDetailModal="openTaskDetailModal")

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -9,7 +9,7 @@
           content-header(:sectionList="filterSections(sectionList)",
                          :tableData="tableData",
                          :taskTotalNumber="taskTotalNumber",
-                         :columns="columnList",
+                         :columns="filteredColumns",
                          @addTask="addTask",
                          @addSection="addSection",
                          @addField="addField",
@@ -18,7 +18,7 @@
           el-collapse(v-model="activeSections")
             draggable
               task-table.mb-500(:tasks="filterTasks(tableData.notSectioned)",
-                                :columns="columnList",
+                                :columns="filteredColumns",
                                 @completeTask="completeTask",
                                 @switchLiked="switchLiked",
                                 @openTaskDetailModal="openTaskDetailModal")
@@ -37,14 +37,14 @@
                              :class="{ 'is-editing': judgeToEdit(section.id) }")
                   j-icon-button.ml-200(genre="far", value="trash-alt", @click.stop="deleteSection(section)")
                 task-table.mt-100(:tasks="filterTasks(tableData[section.value])",
-                                  :columns="columnList",
+                                  :columns="filteredColumns",
                                   @completeTask="completeTask",
                                   @switchLiked="switchLiked",
                                   @openTaskDetailModal="openTaskDetailModal")
       transition(name="task-detail-modal")
         .task-detail-modal-area(v-if="showTaskDetailModal")
           task-detail-modal(:task="taskDetailModalContent",
-                            :columnList="columnList",
+                            :columnList="filteredColumns",
                             @completeTask="completeTask",
                             @uncompleteTask="uncompleteTask",
                             @deleteTask="deleteTask",
@@ -213,6 +213,13 @@ export default {
       },
       taskDetailModalContent: {},
       showTaskDetailModal: false
+    }
+  },
+  computed: {
+    filteredColumns () {
+      return this.columnList.filter((column) => {
+        return column.deletedAt === ''
+      })
     }
   },
   methods: {

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -71,11 +71,11 @@ export default {
   data () {
     return {
       columnList: [
-        { id: 1, label: 'タスク名', value: 'name', type: '文字列', width: 240, visible: true },
-        { id: 2, label: '担当者', value: 'person', type: '文字列', width: 100, visible: true },
-        { id: 3, label: '期日', value: 'deadline', type: '文字列', width: 100, visible: true },
-        { id: 4, label: 'タグ', value: 'tag', type: '文字列', width: 100, visible: true },
-        { id: 5, label: 'その他', value: 'other', type: '文字列', width: 100, visible: false }
+        { id: 1, label: 'タスク名', value: 'name', typeLabel: '文字列', typeValue: 'string', width: 240, visible: true },
+        { id: 2, label: '担当者', value: 'person', typeLabel: '文字列', typeValue: 'string', width: 100, visible: true },
+        { id: 3, label: '期日', value: 'deadline', typeLabel: '文字列', typeValue: 'string', width: 100, visible: true },
+        { id: 4, label: 'タグ', value: 'tag', typeLabel: '文字列', typeValue: 'string', width: 100, visible: true },
+        { id: 5, label: 'その他', value: 'other', typeLabel: '文字列', typeValue: 'string', width: 100, visible: false }
       ],
       sectionList: [
         { id: 1, deletedAt: '', label: '', value: 'notSectioned' },

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -71,11 +71,11 @@ export default {
   data () {
     return {
       columnList: [
-        { id: 1, label: 'タスク名', value: 'name', width: 240, visible: true },
-        { id: 2, label: '担当者', value: 'person', width: 100, visible: true },
-        { id: 3, label: '期日', value: 'deadline', width: 100, visible: true },
-        { id: 4, label: 'タグ', value: 'tag', width: 100, visible: true },
-        { id: 5, label: 'その他', value: 'other', width: 100, visible: false }
+        { id: 1, label: 'タスク名', value: 'name', type: '文字列', width: 240, visible: true },
+        { id: 2, label: '担当者', value: 'person', type: '文字列', width: 100, visible: true },
+        { id: 3, label: '期日', value: 'deadline', type: '文字列', width: 100, visible: true },
+        { id: 4, label: 'タグ', value: 'tag', type: '文字列', width: 100, visible: true },
+        { id: 5, label: 'その他', value: 'other', type: '文字列', width: 100, visible: false }
       ],
       sectionList: [
         { id: 1, deletedAt: '', label: '', value: 'notSectioned' },

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -300,9 +300,11 @@ export default {
       task.deletedAt = Date()
       this.showTaskDetailModal = false
     },
-    deleteField (field) {
-      this.closeTaskDetailModal()
-      field.deletedAt = Date()
+    deleteField (fieldValue) {
+      const targetField = this.columnList.find((column) =>{
+        return column.value === fieldValue
+      })
+      targetField.deletedAt = Date()
     },
     switchLiked (task) {
       if (task.liked) {

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -36,7 +36,7 @@
                              size="medium",
                              :class="{ 'is-editing': judgeToEdit(section.id) }")
                   j-icon-button.ml-200(genre="far", value="trash-alt", @click.stop="deleteSection(section)")
-                task-table.mt-100(:tasks="filterTasks(tableData[section.value])",
+                task-table.mt-100(:tasks="filterTasks(tableData[section.keyName])",
                                   :columns="filteredColumns",
                                   @completeTask="completeTask",
                                   @switchLiked="switchLiked",
@@ -73,16 +73,16 @@ export default {
   data () {
     return {
       columnList: [
-        { id: 1, deletedAt: '', label: 'タスク名', value: 'name', typeLabel: '文字列', typeValue: 'string', width: 240, visible: true },
-        { id: 2, deletedAt: '', label: '担当者', value: 'person', typeLabel: '文字列', typeValue: 'string', width: 120, visible: true },
-        { id: 3, deletedAt: '', label: '期日', value: 'deadline', typeLabel: '文字列', typeValue: 'string', width: 120, visible: true },
-        { id: 4, deletedAt: '', label: '機能の開発区分', value: 'tag', typeLabel: '文字列', typeValue: 'string', width: 120, visible: true },
-        { id: 5, deletedAt: '', label: 'その他', value: 'other', typeLabel: '文字列', typeValue: 'string', width: 120, visible: false }
+        { id: 1, deletedAt: '', label: 'タスク名', keyName: 'name', typeLabel: '文字列', typeValue: 'string', width: 240, visible: true },
+        { id: 2, deletedAt: '', label: '担当者', keyName: 'person', typeLabel: '文字列', typeValue: 'string', width: 120, visible: true },
+        { id: 3, deletedAt: '', label: '期日', keyName: 'deadline', typeLabel: '文字列', typeValue: 'string', width: 120, visible: true },
+        { id: 4, deletedAt: '', label: '機能の開発区分', keyName: 'tag', typeLabel: '文字列', typeValue: 'string', width: 120, visible: true },
+        { id: 5, deletedAt: '', label: 'その他', keyName: 'other', typeLabel: '文字列', typeValue: 'string', width: 120, visible: false }
       ],
       sectionList: [
-        { id: 1, deletedAt: '', label: '', value: 'notSectioned' },
-        { id: 2, deletedAt: '', label: '4/15~29のタスク', value: 'section1' },
-        { id: 3, deletedAt: '', label: '5/04~20のタスク', value: 'section2' }
+        { id: 1, deletedAt: '', label: '', keyName: 'notSectioned' },
+        { id: 2, deletedAt: '', label: '4/15~29のタスク', keyName: 'section1' },
+        { id: 3, deletedAt: '', label: '5/04~20のタスク', keyName: 'section2' }
       ],
       activeSections: [2, 3],
       editingSectionId: '',
@@ -232,7 +232,7 @@ export default {
         id: newSectionId,
         deletedAt: '',
         label: 'セクション' + newSectionId,
-        value: newSectionValue
+        keyName: newSectionValue
       })
       this.activeSections.push(newSectionId)
       this.$set(this.tableData, newSectionValue, [])
@@ -248,8 +248,8 @@ export default {
     addField (field) {
       this.columnList.push(field)
       this.sectionList.forEach((section) => {
-        this.tableData[section.value].forEach((task) => {
-          this.$set(task.data, field.value, '')
+        this.tableData[section.keyName].forEach((task) => {
+          this.$set(task.data, field.keyName, '')
         })
       })
     },
@@ -261,7 +261,7 @@ export default {
     },
     filterSections (sections) {
       return sections.filter((section) => {
-        return section.value !== 'notSectioned' && section.deletedAt === ''
+        return section.keyName !== 'notSectioned' && section.deletedAt === ''
       })
     },
     filterTasks (tasks) {
@@ -312,7 +312,7 @@ export default {
     },
     deleteField (fieldValue) {
       const targetField = this.columnList.find((column) =>{
-        return column.value === fieldValue
+        return column.keyName === fieldValue
       })
       this.$confirm(
         '紐付いた値を含む「' + targetField.label + '」のすべてが削除されます。',

--- a/src/main.js
+++ b/src/main.js
@@ -25,6 +25,13 @@ Vue.component('j-modal', JModal)
 Vue.component('j-switch', JSwitch)
 Vue.component('j-task-line', JTaskLine)
 
+Vue.filter('truncate', (value, length, omission) => {
+  const filterLength = length ? parseInt(length, 10) : 5
+  const filterOmission = omission ? omission.toString() : '...'
+  if (value.length <= filterLength) return value
+  return value.substring(0, filterLength) + filterOmission
+})
+
 new Vue({
   render: h => h(App),
 }).$mount('#app')

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,7 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 
 import App from './App.vue'
 import JIconButton from '@/components/atoms/JIconButton'
+import JModal from '@/components/atoms/JModal'
 import JTaskLine from '@/components/molecules/JTaskLine'
 
 library.add(fas, far, fab)
@@ -19,6 +20,7 @@ Vue.config.productionTip = false
 Vue.use(ElementUI, { locale })
 Vue.component('font-awesome-icon', FontAwesomeIcon)
 Vue.component('j-icon-button', JIconButton)
+Vue.component('j-modal', JModal)
 Vue.component('j-task-line', JTaskLine)
 
 new Vue({


### PR DESCRIPTION
## 概要
- フィールドの追加
- フィールド詳細モーダルにおけるフィールド名変更とフィールド削除

## 技術的変更点概要
- JModal.vue の切り出し
- columnListのデータ構造において、deletedAt/typeLabel/typeValueを持つように

## 使い方
- ホーム画面ヘッダー右の「フィールドを編集」ボタンからフィールド名をクリックする事で詳細モーダルが開く
- そこでフィールド名変更とフィールド削除が可能
![327480d98d68b641bc272b5190590a52](https://user-images.githubusercontent.com/38747501/82164175-2fcdb100-98ea-11ea-90f2-bff93c82c9b2.gif)

## UIに対する変更
- 変更後のスクリーンショット
![スクリーンショット 2020-05-18 9 30 43](https://user-images.githubusercontent.com/38747501/82164198-4ffd7000-98ea-11ea-9b0d-97067dc2a9dc.png)

- 変更前のスクリーンショット
![image](https://user-images.githubusercontent.com/38747501/81896023-9d2dc900-95ee-11ea-8d8e-0eac4c64d15f.png)

## テスト結果とテスト項目
- [x] フィールド詳細モーダルが開けられる
- [x] フィールド詳細モーダルを背景クリックで閉じられる
- [x] フィールド名が変更できる
- [x] フィールドを削除しようとすると確認のモーダルが出る
- [x] 上記で削除を押すと削除される
- [x] 上記でキャンセルを押すと削除されない

## 今回保留した項目とTODOリスト
- 特になし

## その他
- atomの使い方と感覚に慣れてきました

## 関連URL
- 研修の目的
https://smartcamp.kibe.la/notes/3813
- スケジュール
https://smartcamp.kibe.la/notes/3816