### PR TITLE
[XC]各フィールドの並び替え

### DIFF
--- a/src/components/organisms/ContentHeader.vue
+++ b/src/components/organisms/ContentHeader.vue
@@ -89,7 +89,7 @@ export default {
         return this.columns
       },
       set (newOrderColumns) {
-        this.$emit('changeFieldOrder', newOrderColumns)
+        this.$emit('rearrangeColumns', newOrderColumns)
       }
     }
   },
@@ -129,8 +129,7 @@ export default {
         typeLabel: '文字列',
         typeValue: 'string',
         width: 120,
-        visible: true,
-        order: emptyFieldId
+        visible: true
       }
       this.openFieldModal(emptyField)
       this.$emit('addField', emptyField)

--- a/src/components/organisms/ContentHeader.vue
+++ b/src/components/organisms/ContentHeader.vue
@@ -11,12 +11,14 @@
         span(class="el-dropdown-link")
           el-button(icon="el-icon-notebook-2", size="mini") フィールドを編集
         el-dropdown-menu(slot="dropdown")
-          .field-item.px-100(v-for="column in columns", v-if="column.id !== 1")
-            el-dropdown-item(:command="column").column-label {{ column.label }}
-            j-switch.mx-200(v-model="column.visible")
-          hr.my-100
-          .field-item
-            el-button(@click="addField", icon="el-icon-plus", size="mini", type="text") フィールドを追加
+          draggable(group="columns")
+            .field-item.px-100(v-for="column in columns", v-if="column.id !== 1")
+              j-icon-button.mx-200(genre="fas", value="grip-vertical", type="grab")
+              el-dropdown-item(:command="column").column-label {{ column.label }}
+              j-switch.mx-200(v-model="column.visible")
+            hr.my-100
+            .field-item
+              el-button(@click="addField", icon="el-icon-plus", size="mini", type="text") フィールドを追加
     j-modal(v-if="visibleFieldModal", @closeModal="closeFieldModal")
       template(v-slot:header)
         .fw-bold 「{{ selectedField.label }}」フィールドの編集
@@ -34,7 +36,12 @@
 </template>
 
 <script>
+import draggable from 'vuedraggable'
+
 export default {
+  components: {
+    draggable
+  },
   props: {
     sectionList: {
       type: Array,

--- a/src/components/organisms/ContentHeader.vue
+++ b/src/components/organisms/ContentHeader.vue
@@ -11,7 +11,7 @@
         span(class="el-dropdown-link")
           el-button(icon="el-icon-notebook-2", size="mini") フィールドを編集
         el-dropdown-menu(slot="dropdown")
-          draggable(group="columns")
+          draggable(group="columns", @end="onDragEnd")
             .field-item.px-100(v-for="column in columns", v-if="column.id !== 1")
               j-icon-button.mx-200(genre="fas", value="grip-vertical", type="grab")
               el-dropdown-item(:command="column").column-label {{ column.label | truncate }}
@@ -121,7 +121,8 @@ export default {
         typeLabel: '文字列',
         typeValue: 'string',
         width: 120,
-        visible: true
+        visible: true,
+        order: emptyFieldId
       }
       this.openFieldModal(emptyField)
       this.$emit('addField', emptyField)
@@ -129,6 +130,9 @@ export default {
     deleteField () {
       this.$emit('deleteField', this.selectedField.keyName)
       this.closeFieldModal()
+    },
+    onDragEnd (event) {
+      this.$emit('changeFieldOrder', event.oldIndex + 2, event.newIndex + 2)
     },
     openFieldModal (field) {
       this.selectedField = field

--- a/src/components/organisms/ContentHeader.vue
+++ b/src/components/organisms/ContentHeader.vue
@@ -11,7 +11,7 @@
         span(class="el-dropdown-link")
           el-button(icon="el-icon-notebook-2", size="mini") フィールドを編集
         el-dropdown-menu(slot="dropdown")
-          draggable(group="columns", @end="onDragEnd")
+          draggable(v-model="rearrangedColumnns")
             .field-item.px-100(v-for="column in columns", v-if="column.id !== 1")
               j-icon-button.mx-200(genre="fas", value="grip-vertical", type="grab")
               el-dropdown-item(:command="column").column-label {{ column.label | truncate }}
@@ -83,6 +83,14 @@ export default {
         return task.data.name === ''
       })
       return emptyTasks.length > 0
+    },
+    rearrangedColumnns: {
+      get () {
+        return this.columns
+      },
+      set (newOrderColumns) {
+        this.$emit('changeFieldOrder', newOrderColumns)
+      }
     }
   },
   methods: {

--- a/src/components/organisms/ContentHeader.vue
+++ b/src/components/organisms/ContentHeader.vue
@@ -139,9 +139,6 @@ export default {
       this.$emit('deleteField', this.selectedField.keyName)
       this.closeFieldModal()
     },
-    onDragEnd (event) {
-      this.$emit('changeFieldOrder', event.oldIndex + 2, event.newIndex + 2)
-    },
     openFieldModal (field) {
       this.selectedField = field
       this.visibleFieldModal = true

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -20,7 +20,7 @@
           el-collapse(v-model="activeSections")
             draggable
               task-table.mb-500(:tasks="filterTasks(tableData.notSectioned)",
-                                :columns="filteredColumns",
+                                :columns="orderedColumns",
                                 @completeTask="completeTask",
                                 @switchLiked="switchLiked",
                                 @openTaskDetailModal="openTaskDetailModal")
@@ -39,14 +39,14 @@
                              :class="{ 'is-editing': judgeToEdit(section.id) }")
                   j-icon-button.ml-200(genre="far", value="trash-alt", @click.stop="deleteSection(section)")
                 task-table.mt-100(:tasks="filterTasks(tableData[section.keyName])",
-                                  :columns="filteredColumns",
+                                  :columns="orderedColumns",
                                   @completeTask="completeTask",
                                   @switchLiked="switchLiked",
                                   @openTaskDetailModal="openTaskDetailModal")
       transition(name="task-detail-modal")
         .task-detail-modal-area(v-if="showTaskDetailModal")
           task-detail-modal(:task="taskDetailModalContent",
-                            :columnList="filteredColumns",
+                            :columnList="orderedColumns",
                             :subtaskTotalNumber="subtaskTotalNumber",
                             @completeTask="completeTask",
                             @uncompleteTask="uncompleteTask",
@@ -222,6 +222,11 @@ export default {
     filteredColumns () {
       return this.columnList.filter((column) => {
         return column.deletedAt === ''
+      })
+    },
+    orderedColumns () {
+      return this.filteredColumns.slice().sort((columnA, columnB) => {
+        return columnA.order - columnB.order
       })
     }
   },

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -13,7 +13,7 @@
                          @addTask="addTask",
                          @addSection="addSection",
                          @addField="addField",,
-                         @changeFieldOrder="changeFieldOrder"
+                         @rearrangeColumns="rearrangeColumns"
                          @deleteField="deleteField")
         //- TODO: 横にはみ出た場合にスクロールできるように
         el-main
@@ -75,7 +75,7 @@ export default {
   data () {
     return {
       columnList: [
-        { id: 1, deletedAt: '', label: 'タスク名', keyName: 'name', typeLabel: '文字列', typeValue: 'string', width: 240, visible: true},
+        { id: 1, deletedAt: '', label: 'タスク名', keyName: 'name', typeLabel: '文字列', typeValue: 'string', width: 240, visible: true },
         { id: 2, deletedAt: '', label: '担当者', keyName: 'person', typeLabel: '文字列', typeValue: 'string', width: 120, visible: true },
         { id: 3, deletedAt: '', label: '期日', keyName: 'deadline', typeLabel: '文字列', typeValue: 'string', width: 120, visible: true },
         { id: 4, deletedAt: '', label: '機能の開発区分', keyName: 'tag', typeLabel: '文字列', typeValue: 'string', width: 120, visible: true },
@@ -270,7 +270,7 @@ export default {
         return task.deletedAt === '' && task.completedAt === ''
       })
     },
-    changeFieldOrder (newOrderColumns) {
+    rearrangeColumns (newOrderColumns) {
       this.columnList = newOrderColumns
     },
     completeTask (task, isMainTask) {

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -75,11 +75,11 @@ export default {
   data () {
     return {
       columnList: [
-        { id: 1, deletedAt: '', label: 'タスク名', keyName: 'name', typeLabel: '文字列', typeValue: 'string', width: 240, visible: true, order: 1 },
-        { id: 2, deletedAt: '', label: '担当者', keyName: 'person', typeLabel: '文字列', typeValue: 'string', width: 120, visible: true, order: 2 },
-        { id: 3, deletedAt: '', label: '期日', keyName: 'deadline', typeLabel: '文字列', typeValue: 'string', width: 120, visible: true, order: 3 },
-        { id: 4, deletedAt: '', label: '機能の開発区分', keyName: 'tag', typeLabel: '文字列', typeValue: 'string', width: 120, visible: true, order: 4 },
-        { id: 5, deletedAt: '', label: 'その他', keyName: 'other', typeLabel: '文字列', typeValue: 'string', width: 120, visible: false, order: 5 }
+        { id: 1, deletedAt: '', label: 'タスク名', keyName: 'name', typeLabel: '文字列', typeValue: 'string', width: 240, visible: true},
+        { id: 2, deletedAt: '', label: '担当者', keyName: 'person', typeLabel: '文字列', typeValue: 'string', width: 120, visible: true },
+        { id: 3, deletedAt: '', label: '期日', keyName: 'deadline', typeLabel: '文字列', typeValue: 'string', width: 120, visible: true },
+        { id: 4, deletedAt: '', label: '機能の開発区分', keyName: 'tag', typeLabel: '文字列', typeValue: 'string', width: 120, visible: true },
+        { id: 5, deletedAt: '', label: 'その他', keyName: 'other', typeLabel: '文字列', typeValue: 'string', width: 120, visible: false }
       ],
       sectionList: [
         { id: 1, deletedAt: '', label: '4/15~29のタスク', keyName: 'section1' },

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -20,7 +20,7 @@
           el-collapse(v-model="activeSections")
             draggable
               task-table.mb-500(:tasks="filterTasks(tableData.notSectioned)",
-                                :columns="orderedColumns",
+                                :columns="filteredColumns",
                                 @completeTask="completeTask",
                                 @switchLiked="switchLiked",
                                 @openTaskDetailModal="openTaskDetailModal")
@@ -39,14 +39,14 @@
                              :class="{ 'is-editing': judgeToEdit(section.id) }")
                   j-icon-button.ml-200(genre="far", value="trash-alt", @click.stop="deleteSection(section)")
                 task-table.mt-100(:tasks="filterTasks(tableData[section.keyName])",
-                                  :columns="orderedColumns",
+                                  :columns="filteredColumns",
                                   @completeTask="completeTask",
                                   @switchLiked="switchLiked",
                                   @openTaskDetailModal="openTaskDetailModal")
       transition(name="task-detail-modal")
         .task-detail-modal-area(v-if="showTaskDetailModal")
           task-detail-modal(:task="taskDetailModalContent",
-                            :columnList="orderedColumns",
+                            :columnList="filteredColumns",
                             :subtaskTotalNumber="subtaskTotalNumber",
                             @completeTask="completeTask",
                             @uncompleteTask="uncompleteTask",
@@ -223,11 +223,6 @@ export default {
       return this.columnList.filter((column) => {
         return column.deletedAt === ''
       })
-    },
-    orderedColumns () {
-      return this.filteredColumns.slice().sort((columnA, columnB) => {
-        return columnA.order - columnB.order
-      })
     }
   },
   methods: {
@@ -275,24 +270,8 @@ export default {
         return task.deletedAt === '' && task.completedAt === ''
       })
     },
-    changeFieldOrder (oldFieldOrder, newFieldOrder) {
-      if (oldFieldOrder < newFieldOrder) {
-        this.columnList.forEach((column) => {
-          if (column.order === oldFieldOrder) {
-            column.order = newFieldOrder
-          } else if (column.order > oldFieldOrder && column.order <= newFieldOrder) {
-            column.order -= 1
-          }
-        })
-      } else if (oldFieldOrder > newFieldOrder) {
-        this.columnList.forEach((column) => {
-          if (column.order === oldFieldOrder) {
-            column.order = newFieldOrder
-          } else if (column.order < oldFieldOrder && column.order >= newFieldOrder) {
-            column.order += 1
-          }
-        })
-      }
+    changeFieldOrder (newOrderColumns) {
+      this.columnList = newOrderColumns
     },
     completeTask (task, isMainTask) {
       task.completedAt = Date()

--- a/src/components/pages/Home.vue
+++ b/src/components/pages/Home.vue
@@ -12,7 +12,8 @@
                          :columns="filteredColumns",
                          @addTask="addTask",
                          @addSection="addSection",
-                         @addField="addField",
+                         @addField="addField",,
+                         @changeFieldOrder="changeFieldOrder"
                          @deleteField="deleteField")
         //- TODO: 横にはみ出た場合にスクロールできるように
         el-main
@@ -74,11 +75,11 @@ export default {
   data () {
     return {
       columnList: [
-        { id: 1, deletedAt: '', label: 'タスク名', keyName: 'name', typeLabel: '文字列', typeValue: 'string', width: 240, visible: true },
-        { id: 2, deletedAt: '', label: '担当者', keyName: 'person', typeLabel: '文字列', typeValue: 'string', width: 120, visible: true },
-        { id: 3, deletedAt: '', label: '期日', keyName: 'deadline', typeLabel: '文字列', typeValue: 'string', width: 120, visible: true },
-        { id: 4, deletedAt: '', label: '機能の開発区分', keyName: 'tag', typeLabel: '文字列', typeValue: 'string', width: 120, visible: true },
-        { id: 5, deletedAt: '', label: 'その他', keyName: 'other', typeLabel: '文字列', typeValue: 'string', width: 120, visible: false }
+        { id: 1, deletedAt: '', label: 'タスク名', keyName: 'name', typeLabel: '文字列', typeValue: 'string', width: 240, visible: true, order: 1 },
+        { id: 2, deletedAt: '', label: '担当者', keyName: 'person', typeLabel: '文字列', typeValue: 'string', width: 120, visible: true, order: 2 },
+        { id: 3, deletedAt: '', label: '期日', keyName: 'deadline', typeLabel: '文字列', typeValue: 'string', width: 120, visible: true, order: 3 },
+        { id: 4, deletedAt: '', label: '機能の開発区分', keyName: 'tag', typeLabel: '文字列', typeValue: 'string', width: 120, visible: true, order: 4 },
+        { id: 5, deletedAt: '', label: 'その他', keyName: 'other', typeLabel: '文字列', typeValue: 'string', width: 120, visible: false, order: 5 }
       ],
       sectionList: [
         { id: 1, deletedAt: '', label: '4/15~29のタスク', keyName: 'section1' },
@@ -268,6 +269,25 @@ export default {
       return tasks.filter((task) => {
         return task.deletedAt === '' && task.completedAt === ''
       })
+    },
+    changeFieldOrder (oldFieldOrder, newFieldOrder) {
+      if (oldFieldOrder < newFieldOrder) {
+        this.columnList.forEach((column) => {
+          if (column.order === oldFieldOrder) {
+            column.order = newFieldOrder
+          } else if (column.order > oldFieldOrder && column.order <= newFieldOrder) {
+            column.order -= 1
+          }
+        })
+      } else if (oldFieldOrder > newFieldOrder) {
+        this.columnList.forEach((column) => {
+          if (column.order === oldFieldOrder) {
+            column.order = newFieldOrder
+          } else if (column.order < oldFieldOrder && column.order >= newFieldOrder) {
+            column.order += 1
+          }
+        })
+      }
     },
     completeTask (task, isMainTask) {
       task.completedAt = Date()


### PR DESCRIPTION
## 概要
- 各フィールドの並び替え

## 技術的変更点概要
- Draggableの`@end="onDragEnd"`でユーザーが並び替えた内容を検知
- columnListにorderプロパティを持たせてそれで並び順を管理

## 使い方
- ホーム画面ヘッダー右の「フィールドを編集」ボタンメニューからドラッグで並び替え
![48c2c4838b659d14cacb04bfd9a05f16](https://user-images.githubusercontent.com/38747501/82410311-90a3e780-9aaa-11ea-8def-1f1542428a4f.gif)

## UIに対する変更
- 変更後のスクリーンショット
![image](https://user-images.githubusercontent.com/38747501/82410347-a6191180-9aaa-11ea-995f-fcd841f6d1c7.png)

- 変更前のスクリーンショット
![スクリーンショット 2020-05-18 9 30 43](https://user-images.githubusercontent.com/38747501/82164198-4ffd7000-98ea-11ea-9b0d-97067dc2a9dc.png)

## テスト結果とテスト項目
- [x] フィールドを上から下に並び替えた時に反映される
- [x] フィールドを下から上に並び替えた時に反映される
- [x] フィールドをドラッグしたが並び替えなかった時に何も起きない
- [x] フィールドを並び替えた後にフィールド表示/非表示を切り替えても適切に反映されている
- [x] フィールドを追加後にフィールドを並び替えても適切に反映されている
- [x] フィールドを削除後にフィールドを並び替えても適切に反映されている

## 今回保留した項目とTODOリスト
- [x] フィールドを削除しても正しく並び替えが反映されるように

## その他
- ストレッチ目標クリアまであと1機能です！

## 関連URL
- 研修の目的
https://smartcamp.kibe.la/notes/3813
- スケジュール
https://smartcamp.kibe.la/notes/3816